### PR TITLE
verify on deploy via etherscan

### DIFF
--- a/packages/smart/hardhat.config.ts
+++ b/packages/smart/hardhat.config.ts
@@ -10,6 +10,9 @@ import { HardhatUserConfig } from "hardhat/config";
 import "./tasks/balance.ts";
 import "./tasks/accounts.ts";
 import "./tasks/deploy.ts";
+import "./tasks/verifyDeploy.ts";
+
+const ETHERSCAN_API_KEY = process.env["ETHERSCAN_API_KEY"] || "CH7M2ATCZABP2GIHEF3FREWWQPDFQBSH8G";
 
 const config: HardhatUserConfig = {
   solidity: {
@@ -42,6 +45,9 @@ const config: HardhatUserConfig = {
     path: "./docs",
     clear: true,
   },
+  etherscan: {
+    apiKey: ETHERSCAN_API_KEY,
+  },
 };
 
 const PRIVATE_KEY = process.env["PRIVATE_KEY"];
@@ -49,7 +55,6 @@ if (PRIVATE_KEY && config.networks?.kovan) {
   config.networks.kovan.accounts = [PRIVATE_KEY];
 }
 
-const ETHERSCAN_API_KEY = process.env["ETHERSCAN_API_KEY"] || "CH7M2ATCZABP2GIHEF3FREWWQPDFQBSH8G";
 if (ETHERSCAN_API_KEY) config.etherscan = { apiKey: ETHERSCAN_API_KEY };
 
 export default config;

--- a/packages/smart/tasks/deploy.ts
+++ b/packages/smart/tasks/deploy.ts
@@ -1,4 +1,5 @@
 import { task } from "hardhat/config";
+import "@nomiclabs/hardhat-etherscan";
 
 import {
   ContractDeployConfig,
@@ -22,6 +23,14 @@ task("deploy", "Deploy Turbo").setAction(async (args, hre) => {
   } else {
     const { externalAddresses } = hre.config.contractDeploy;
     deploy = await deployer.deployProduction(externalAddresses);
+  }
+
+  // Verify deploy
+  if (hre.network.name !== "localhost" && deploy && deploy.addresses) {
+    await hre.run("verifyDeploy", {
+      account: await signer.getAddress(),
+      addresses: JSON.stringify(deploy.addresses),
+    });
   }
 
   console.log(JSON.stringify(deploy, null, 2));

--- a/packages/smart/tasks/verifyDeploy.ts
+++ b/packages/smart/tasks/verifyDeploy.ts
@@ -1,0 +1,48 @@
+import { task } from "hardhat/config";
+task("verifyDeploy", "Verify contract deploy")
+  .addParam("addresses", "Deployed addresses")
+  .addParam("account", "The account's address")
+  .setAction(async (args, hre) => {
+    const deployedAddresses = JSON.parse(args.addresses);
+    const { collateral, reputationToken, balancerFactory, hatcheryRegistry, ammFactory } = deployedAddresses;
+    const account = args.account;
+
+    if (collateral) {
+      console.log("verify::collateral", collateral);
+      await hre.run("verify:verify", {
+        address: collateral,
+        constructorArguments: ["USDC", "USDC", 18],
+      });
+    }
+
+    if (reputationToken) {
+      console.log("verify::reputationToken", reputationToken);
+      await hre.run("verify:verify", {
+        address: reputationToken,
+        constructorArguments: ["REPv2", "REPv2", 18],
+      });
+    }
+
+    if (balancerFactory) {
+      console.log("verify::balancerFactory", balancerFactory);
+      await hre.run("verify:verify", {
+        address: balancerFactory,
+      });
+    }
+
+    if (hatcheryRegistry) {
+      console.log("verify::hatcheryRegistry", hatcheryRegistry);
+      await hre.run("verify:verify", {
+        address: hatcheryRegistry,
+        constructorArguments: [account, reputationToken],
+      });
+    }
+
+    if (ammFactory) {
+      console.log("verify::ammFactory", ammFactory);
+      await hre.run("verify:verify", {
+        address: ammFactory,
+        constructorArguments: [balancerFactory],
+      });
+    }
+  });


### PR DESCRIPTION
@robert-e-davidson3 Currently i'm passing the deploy artifacts into the verify task via args...  should we be pulling this from build artifacts instead?

