### PR TITLE
allow selecting no contest in trading form

### DIFF
--- a/packages/comps/src/assets/styles/_colors.less
+++ b/packages/comps/src/assets/styles/_colors.less
@@ -168,7 +168,7 @@
 
 
 // simplified outcome colors
-
+@outcome-simp-0: #58586B; //--simple-invalid;
 @outcome-simp-1: #05B169; //--simple-yes;
 @outcome-simp-2: #FF7D5E; //--finance-color; 
 @outcome-simp-3:  #73D2DE; //--medical-color; 
@@ -178,7 +178,7 @@
 @outcome-simp-7: #1F71B5; //--politics-color; 
 @outcome-simp-8: #58586B; //--simple-invalid;
 
-@color-simp-outcome-list: @outcome-simp-1 @outcome-simp-2 @outcome-simp-3 @outcome-simp-4 @outcome-simp-5 @outcome-simp-6 @outcome-simp-7 @outcome-simp-8;
+@color-simp-outcome-list: @outcome-simp-0 @outcome-simp-1 @outcome-simp-2 @outcome-simp-3 @outcome-simp-4 @outcome-simp-5 @outcome-simp-6 @outcome-simp-7 @outcome-simp-8;
 
 .generate-trading-indexed-color-outcome-classes(@rules) {
   each(@color-simp-outcome-list, {

--- a/packages/comps/src/components/common/inputs.tsx
+++ b/packages/comps/src/components/common/inputs.tsx
@@ -228,7 +228,7 @@ const Outcome = ({
   return (
     <div
       onClick={onClick}
-      className={classNames(Styles.Outcome, `${Styles[`color-${index + 1}`]}`, {
+      className={classNames(Styles.Outcome, `${Styles[`color-${outcome.id + 1}`]}`, {
         [Styles.Selected]: selected,
         [Styles.ShowAllHighlighted]: showAllHighlighted,
         [Styles.nonSelectable]: nonSelectable,

--- a/packages/comps/src/components/common/inputs.tsx
+++ b/packages/comps/src/components/common/inputs.tsx
@@ -229,7 +229,7 @@ const Outcome = ({
   const formattedPrice = formatDai(outcome.price);
   return (
     <div
-      onClick={() => (outcome.isInvalid ? null : onClick())}
+      onClick={onClick}
       className={classNames(Styles.Outcome, `${Styles[`color-${index + 1}`]}`, {
         [Styles.Selected]: selected,
         [Styles.ShowAllHighlighted]: showAllHighlighted,
@@ -263,17 +263,12 @@ const Outcome = ({
           />
         </div>
       ) : (
-        <>
-          {!outcome.isInvalid && (
             <span>
               {
                 formatCashPrice(formattedPrice.fullPrecision, ammCash?.name)
                   .full
               }
             </span>
-          )}
-          {outcome.isInvalid && LinkIcon}
-        </>
       )}
     </div>
   );
@@ -326,7 +321,7 @@ export const OutcomesGrid = ({
             selected={
               selectedOutcome &&
               (outcome.id === selectedOutcome.id ||
-                (showAllHighlighted && !outcome.isInvalid))
+                showAllHighlighted)
             }
             index={index}
             nonSelectable={nonSelectable}

--- a/packages/comps/src/components/common/inputs.tsx
+++ b/packages/comps/src/components/common/inputs.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
-import { EthIcon, LinkIcon, UsdIcon, XIcon } from './icons';
+import { EthIcon, UsdIcon, XIcon } from './icons';
 import Styles from './inputs.styles.less';
 import {
   getCashFormat,
@@ -13,8 +13,6 @@ import {
   USDC,
   ERROR_AMOUNT,
   SHARES,
-  YES_OUTCOME_ID,
-  YES_NO,
   ETH,
 } from '../../utils/constants';
 import { useAppStatusStore } from '../../stores/app-status';
@@ -237,7 +235,7 @@ const Outcome = ({
         [Styles.Edited]: customVal !== '',
         [Styles.showAsButton]: showAsButton,
         [Styles.loggedOut]: !isLogged,
-        [Styles.disabled]: !isLogged && outcome.isInvalid,
+        [Styles.disabled]: !isLogged,
         [Styles.Error]: error,
         [Styles.noClick]: noClick,
       })}

--- a/packages/simplified/src/assets/styles/_colors.less
+++ b/packages/simplified/src/assets/styles/_colors.less
@@ -186,6 +186,7 @@
   --simple-brand: #2AE7A8;
 }
 
+@outcome-simp-0: #58586B; //--simple-invalid;
 @outcome-simp-1: #05B169; //--simple-yes;
 @outcome-simp-2: #FF7D5E; //--finance-color; 
 @outcome-simp-3:  #73D2DE; //--medical-color; 
@@ -195,7 +196,7 @@
 @outcome-simp-7: #1F71B5; //--politics-color; 
 @outcome-simp-8: #58586B; //--simple-invalid;
 
-@color-outcome-list: @outcome-simp-1 @outcome-simp-2 @outcome-simp-3 @outcome-simp-4 @outcome-simp-5 @outcome-simp-6 @outcome-simp-7 @outcome-simp-8;
+@color-outcome-list: @outcome-simp-0 @outcome-simp-1 @outcome-simp-2 @outcome-simp-3 @outcome-simp-4 @outcome-simp-5 @outcome-simp-6 @outcome-simp-7 @outcome-simp-8;
 
 .generate-trading-indexed-color-outcome-classes(@rules) {
   each(@color-outcome-list, {

--- a/packages/simplified/src/modules/market/market-view.tsx
+++ b/packages/simplified/src/modules/market/market-view.tsx
@@ -192,6 +192,7 @@ const MarketView = ({ defaultMarket = null }) => {
           marketType={YES_NO}
           orderType={BUY}
           ammCash={amm?.cash}
+          dontFilterInvalid
           noClick
         />
         <SimpleChartSection {...{ market, cash: amm?.cash }} />

--- a/packages/simplified/src/modules/market/trading-form.tsx
+++ b/packages/simplified/src/modules/market/trading-form.tsx
@@ -434,6 +434,7 @@ const TradingForm = ({
           marketType={marketType}
           orderType={orderType}
           ammCash={ammCash}
+          dontFilterInvalid
         />
         <AmountInput
           chosenCash={isBuy ? ammCash?.name : SHARES}

--- a/packages/simplified/src/modules/modal/modal-add-liquidity.tsx
+++ b/packages/simplified/src/modules/modal/modal-add-liquidity.tsx
@@ -641,6 +641,7 @@ const ModalAddLiquidity = ({
                   setEditableValue={(price, index) => setPrices(price, index)}
                   ammCash={cash}
                   error={hasPriceErrors}
+                  dontFilterInvalid
                 />
               </>
             )}


### PR DESCRIPTION
show "No Contest" outcome in the trading form and allow it to be selected, also so in add liquidity modal. 

![image](https://user-images.githubusercontent.com/3970376/114866558-5675bf80-9db9-11eb-8ad8-4cb87e7e4ca0.png)
