### PR TITLE
update home and away to match ui

### DIFF
--- a/packages/smart/contracts/turbo/SportsLinkMarketFactory.sol
+++ b/packages/smart/contracts/turbo/SportsLinkMarketFactory.sol
@@ -101,8 +101,8 @@ contract SportsLinkMarketFactory is AbstractMarketFactory, Ownable {
     ) internal returns (uint256) {
         string[] memory _outcomes = new string[](3);
         _outcomes[0] = "No Contest";
-        _outcomes[1] = "Home";
-        _outcomes[2] = "Away";
+        _outcomes[1] = "Away";
+        _outcomes[2] = "Home";
 
         uint256 _id = markets.length;
         markets.push(
@@ -147,8 +147,8 @@ contract SportsLinkMarketFactory is AbstractMarketFactory, Ownable {
     ) internal returns (uint256) {
         string[] memory _outcomes = new string[](3);
         _outcomes[0] = "No Contest";
-        _outcomes[1] = "Home";
-        _outcomes[2] = "Away";
+        _outcomes[1] = "Away";
+        _outcomes[2] = "Home";
 
         uint256 _id = markets.length;
         markets.push(

--- a/packages/smart/test/link-factory-test.ts
+++ b/packages/smart/test/link-factory-test.ts
@@ -84,7 +84,7 @@ describe("LinkFactory", () => {
 
   it("head to head market is correct", async () => {
     const headToHeadMarket = await marketFactory.getMarket(headToHeadMarketId);
-    const [noContest, home, away] = headToHeadMarket.shareTokens.map((addr) =>
+    const [noContest, away, home] = headToHeadMarket.shareTokens.map((addr) =>
       OwnedERC20__factory.connect(addr, signer)
     );
     expect(await noContest.symbol()).to.equal("No Contest");
@@ -97,7 +97,7 @@ describe("LinkFactory", () => {
 
   it("spread market is correct", async () => {
     const spreadMarket = await marketFactory.getMarket(spreadMarketId);
-    const [noContest, home, away] = spreadMarket.shareTokens.map((addr) => OwnedERC20__factory.connect(addr, signer));
+    const [noContest, away, home] = spreadMarket.shareTokens.map((addr) => OwnedERC20__factory.connect(addr, signer));
     expect(await noContest.symbol()).to.equal("No Contest");
     expect(await noContest.name()).to.equal("No Contest");
     expect(await away.symbol()).to.equal("Away");


### PR DESCRIPTION
I mistakenly switched home and away on previous PR. outcomes are No Contest, Away, Home