### PR TITLE
market-filters

### DIFF
--- a/packages/simplified/src/modules/markets/markets-view.styles.less
+++ b/packages/simplified/src/modules/markets/markets-view.styles.less
@@ -79,10 +79,6 @@
     // padding: @size-16;
     padding-bottom: @size-40;
 
-    > ul {
-      display: none;
-    }
-
     > section {
       grid-template-columns: 1fr 1fr;
       grid-gap: @size-16;
@@ -115,6 +111,10 @@
   .MarketsView {
     padding: @size-16;
     padding-bottom: @size-40;
+
+    > ul {
+      display: none;
+    }
   }
 }
 

--- a/packages/simplified/src/modules/markets/markets-view.tsx
+++ b/packages/simplified/src/modules/markets/markets-view.tsx
@@ -28,7 +28,7 @@ const {
   ALL_CURRENCIES,
   ALL_MARKETS,
   categoryItems,
-  currencyItems,
+  // currencyItems,
   marketStatusItems,
   OPEN,
   OTHER,
@@ -76,12 +76,12 @@ const applyFiltersAndSort = (
   }
 
   updatedFilteredMarkets = updatedFilteredMarkets.filter((market: MarketInfo) => {
-    if (showLiquidMarkets && (!market.amm || isNaN(market?.amm?.liquidityUSD) || !market?.amm?.liquidityUSD)) {
+    if (showLiquidMarkets && (!market.amm || !market.amm.hasLiquidity)) {
       return false;
     }
-    if (market.isInvalid) {
-      return false;
-    }
+    // if (market.isInvalid) {
+    //   return false;
+    // }
     if (
       categories !== ALL_MARKETS &&
       categories !== OTHER &&
@@ -253,13 +253,13 @@ const MarketsView = () => {
           options={marketStatusItems}
           defaultValue={reportingState}
         />
-        <SquareDropdown
+        {/* <SquareDropdown
           onChange={(value) => {
             updateMarketsViewSettings({ currency: value });
           }}
           options={currencyItems}
           defaultValue={currency}
-        />
+        /> */}
         <SearchButton
           selected={showFilter}
           action={() => {

--- a/packages/simplified/src/modules/sidebar/sidebar.tsx
+++ b/packages/simplified/src/modules/sidebar/sidebar.tsx
@@ -17,7 +17,7 @@ const {
   SIDEBAR_TYPES,
   DEFAULT_MARKET_VIEW_SETTINGS,
   categoryItems,
-  currencyItems,
+  // currencyItems,
   marketStatusItems,
   sortByItems,
 } = Constants;
@@ -84,14 +84,14 @@ const FilterSideBar = () => {
           selected={localSettings.reportingState}
           items={marketStatusItems}
         />
-        <RadioBarGroup
+        {/* <RadioBarGroup
           title="currency"
           update={(value) => {
             setLocalSettings({ ...localSettings, currency: value });
           }}
           selected={localSettings.currency}
           items={currencyItems}
-        />
+        /> */}
       </div>
       <div className={Styles.Footer}>
         <SecondaryButton


### PR DESCRIPTION
commented out the currency dropdowns, corrected an issue where ipad pros had no way to adjust filters in portrait mode, adjusted show liquid markets only setting to actaully properly filter again.