### PR TITLE
update rate warning

### DIFF
--- a/packages/comps/src/components/common/inputs.styles.less
+++ b/packages/comps/src/components/common/inputs.styles.less
@@ -199,11 +199,15 @@
   grid-column: 1 / span 2;
   height: @size-16;
 
-  > span {
-    .text-14;
+  > span:not(:last-of-type) {
 
     margin-right: @size-4;
-    color: var(--simple-secondary-text);
+
+    &:first-of-type { 
+      .text-14;
+
+      color: var(--simple-secondary-text);
+    }
   }
 }
 

--- a/packages/comps/src/components/common/inputs.tsx
+++ b/packages/comps/src/components/common/inputs.tsx
@@ -65,7 +65,7 @@ export interface AmountInputProps {
   showCurrencyDropdown?: boolean;
   updateCash?: (string) => void;
   chosenCash: string;
-  rate?: string | null;
+  rate?: React.Fragment | null;
   error?: boolean;
   updateAmountError?: Function;
   ammCash: Cash;

--- a/packages/simplified/src/modules/market/trading-form.styles.less
+++ b/packages/simplified/src/modules/market/trading-form.styles.less
@@ -116,6 +116,10 @@
   }
 }
 
+.rateWarning {
+  color: var(--simple-failed);
+}
+
 @media @breakpoint-mobile-tiny {
   .TradingForm {
     filter: unset;

--- a/packages/simplified/src/modules/modal/modal-add-liquidity.tsx
+++ b/packages/simplified/src/modules/modal/modal-add-liquidity.tsx
@@ -25,7 +25,7 @@ const {
   estimateAddLiquidityPool,
   getRemoveLiquidity,
 } = ContractCalls;
-const { formatPercent, lpTokensOnChainToDisplay, formatSimpleShares } = Formatter;
+const { formatPercent, formatSimpleShares } = Formatter;
 const {
   Icons: { BackIcon },
   ButtonComps: { ApprovalButton, BuySellButton },


### PR DESCRIPTION
updated getRate and style of rate to add a warning threshold, in this case 10%, which will color the rate in --simple-failed to alert the user to the high rate impact.

https://github.com/AugurProject/turbo/issues/448