### PR TITLE
hide-expires

### DIFF
--- a/packages/simplified/src/modules/market/market-view.styles.less
+++ b/packages/simplified/src/modules/market/market-view.styles.less
@@ -434,15 +434,15 @@
   }
 
   .StatsRow {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    height: unset;
+    // display: grid;
+    // grid-template-columns: repeat(3, 1fr);
+    // height: unset;
     margin-bottom: @size-24;
 
     > li {
       padding: @size-12;
-      height: unset;
-      grid-gap: @size-4;
+      // height: unset;
+      // grid-gap: @size-4;
 
       > span:first-of-type {
         .text-12;
@@ -452,10 +452,10 @@
         .text-16-semi-bold;
       }
 
-      &:last-of-type {
-        grid-column: 1 / span 3;
-        border-top: @size-1 solid var(--simple-border);
-      }
+      // &:last-of-type {
+      //   grid-column: 1 / span 3;
+      //   border-top: @size-1 solid var(--simple-border);
+      // }
     }
   }
 }

--- a/packages/simplified/src/modules/market/market-view.tsx
+++ b/packages/simplified/src/modules/market/market-view.tsx
@@ -141,7 +141,7 @@ const MarketView = ({ defaultMarket = null }) => {
   // @ts-ignore
   const market: MarketInfo = !!defaultMarket ? defaultMarket : markets[marketId];
 
-  const endTimeDate = useMemo(() => getMarketEndtimeDate(market?.endTimestamp), [market?.endTimestamp]);
+  // const endTimeDate = useMemo(() => getMarketEndtimeDate(market?.endTimestamp), [market?.endTimestamp]);
   const selectedOutcome = market ? market.outcomes[1] : DefaultMarketOutcomes[1];
   // add end time data full to market details when design is ready
   // const endTimeDateFull = useMemo(() => getMarketEndtimeFull(market?.endTimestamp), [market?.endTimestamp]);
@@ -192,10 +192,10 @@ const MarketView = ({ defaultMarket = null }) => {
             <span>Liquidity</span>
             <span>{formatDai(amm?.liquidityUSD || "0.00").full}</span>
           </li>
-          <li>
+          {/* <li>
             <span>Expires</span>
             <span>{endTimeDate}</span>
-          </li>
+          </li> */}
         </ul>
         <OutcomesGrid
           outcomes={amm?.ammOutcomes}


### PR DESCRIPTION
commented out expires and adjusted styles for mobile to now use 2 rows. commented for now so we can just easily uncomment later when we fill that back in.

examples:

<img width="917" alt="Screen Shot 2021-05-12 at 11 58 47 AM" src="https://user-images.githubusercontent.com/10524630/118015003-6aa9cf80-b319-11eb-85a4-4fdaebf7e0f3.png">

<img width="1085" alt="Screen Shot 2021-05-12 at 11 56 51 AM" src="https://user-images.githubusercontent.com/10524630/118014939-5d8ce080-b319-11eb-85b2-359ea305e950.png">
<img width="874" alt="Screen Shot 2021-05-12 at 11 56 45 AM" src="https://user-images.githubusercontent.com/10524630/118014942-5e257700-b319-11eb-9e5c-d6d65aa64ffd.png">
<img width="917" alt="Screen Shot 2021-05-12 at 11 56 37 AM" src="https://user-images.githubusercontent.com/10524630/118014943-5e257700-b319-11eb-9915-78817d5e5646.png">
<img width="440" alt="Screen Shot 2021-05-12 at 11 56 32 AM" src="https://user-images.githubusercontent.com/10524630/118014944-5ebe0d80-b319-11eb-8e4f-aefa72f7f0cb.png">
