### PR TITLE
update-claim-all-disabled

### DIFF
--- a/packages/simplified/src/modules/common/tables.tsx
+++ b/packages/simplified/src/modules/common/tables.tsx
@@ -11,6 +11,7 @@ import {
   SimpleBalance,
   Winnings,
 } from "../types";
+import { getClaimAllMessage } from '../portfolio/portfolio-view';
 import {
   useAppStatusStore,
   useDataStore,
@@ -170,10 +171,12 @@ export const PositionFooter = ({
     shareToken: ammCash?.sharetoken,
   });
   const isETHClaim = ammCash?.name === ETH;
+  
   const disableClaim =
     pendingClaim ||
     (pendingClaimHash &&
-      Boolean(transactions.find((t) => t.hash === pendingClaimHash && t.status === TX_STATUS.PENDING)));
+      Boolean(transactions.find((t) => t.status === TX_STATUS.PENDING && (t.hash === pendingClaimHash || t.message === getClaimAllMessage(ammCash)))));
+
   const disableCashOut =
     pendingCashOut ||
     (pendingCashOutHash &&

--- a/packages/simplified/src/modules/portfolio/activity.tsx
+++ b/packages/simplified/src/modules/portfolio/activity.tsx
@@ -35,7 +35,7 @@ const ActivityCard = ({ activity, timeFormat }: typeof React.Component) => (
         )}
       </span>
     </MarketLink>
-    {activity.subheader && <div className={Styles.subheader}>{activity.subheader}</div>}
+    <div className={Styles.subheader}>{activity.subheader || ''}</div>
     <div className={Styles.time}>{getTimeFormat(activity.timestamp, timeFormat)}</div>
     {activity.txHash && <ReceiptLink hash={activity.txHash} />}
   </div>


### PR DESCRIPTION
updated claim all winnings button to properly stay disabled when a claim all winnings transaction is still pending, also updated all position footers for individual markets to disable claim individual winnings button on footer if claim all is pending. updated activity to always render subheader div.

https://github.com/AugurProject/turbo/issues/423