### PR TITLE
Resolved market touchups

### DIFF
--- a/packages/comps/src/components/market-card/market-card.tsx
+++ b/packages/comps/src/components/market-card/market-card.tsx
@@ -10,6 +10,7 @@ import { MARKET_STATUS, TWELVE_HOUR_TIME } from "../../utils/constants";
 import { PrimaryButton } from "../common/buttons";
 import { MarketLink } from "../../utils/links/links";
 import { ConfirmedCheck } from "../common/icons";
+import { isMarketFinal } from '../../stores/utils';
 
 export const LoadingMarketCard = () => {
   return (
@@ -153,7 +154,7 @@ export const MarketCardView = ({
         [Styles.NoLiquidity]: !amm?.id,
       })}
       onClick={() => {
-        !amm?.id && handleNoLiquidity(market);
+        !amm?.id && !isMarketFinal(market) && handleNoLiquidity(market);
       }}
     >
       <div>

--- a/packages/comps/src/index.tsx
+++ b/packages/comps/src/index.tsx
@@ -63,6 +63,7 @@ import {
   arrayToKeyedObject,
   arrayToKeyedObjectByProp,
   useApprovalStatus,
+  isMarketFinal,
 } from './stores/utils';
 import * as _ApprovalHooks from './stores/use-approval-callback';
 import * as _GraphClient from './apollo/client';
@@ -105,6 +106,7 @@ export const Stores = {
     keyedObjToKeyArray,
     arrayToKeyedObject,
     arrayToKeyedObjectByProp,
+    isMarketFinal,
   },
   Constants: _StoreConstants
 };

--- a/packages/comps/src/stores/utils.ts
+++ b/packages/comps/src/stores/utils.ts
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from "react";
 import { checkIsERC20Approved, checkIsERC1155Approved, checkAllowance } from "./use-approval-callback";
 import { Cash, MarketInfo, TransactionDetails, AmmExchange } from "../types";
 import { PARA_CONFIG } from "./constants";
-import { ETH, TX_STATUS, ApprovalAction, ApprovalState } from "../utils/constants";
+import { ETH, TX_STATUS, ApprovalAction, ApprovalState, MARKET_STATUS } from "../utils/constants";
 import { useAppStatusStore } from "./app-status";
 import { useUserStore } from "./user";
 import { getUserBalances } from "../utils/contract-calls";
@@ -34,6 +34,8 @@ export const getRelatedMarkets = (market: MarketInfo, markets: Array<MarketInfo>
   keyedObjToKeyArray(markets)
     .filter((mrkt) => mrkt.includes(market.marketId))
     .map((mid) => markets[mid]);
+
+export const isMarketFinal = (market: MarketInfo) => market.reportingState === MARKET_STATUS.FINALIZED;
 
 export const getCurrentAmms = (market: MarketInfo, markets: Array<MarketInfo>) =>
   getRelatedMarkets(market, markets).map((m) => m.amm.cash.name);

--- a/packages/simplified/src/modules/common/labels.tsx
+++ b/packages/simplified/src/modules/common/labels.tsx
@@ -12,9 +12,12 @@ import {
   Constants,
   PARA_CONFIG,
   LabelComps,
+  Stores,
 } from "@augurproject/comps";
 import type { MarketInfo } from "@augurproject/comps/build/types";
-
+const {
+  Utils: { isMarketFinal }
+} = Stores;
 const {
   CREATE,
   USDC,
@@ -79,7 +82,7 @@ export const AddLiquidity = ({ market }: { market: MarketInfo }) => {
           });
         }
       }}
-      disabled={!isLogged}
+      disabled={!isLogged || isMarketFinal(market)}
     >
       <span>
         {PlusIcon}
@@ -109,7 +112,7 @@ export const AddCurrencyLiquidity = ({ market, currency }: { market: MarketInfo;
           });
         }
       }}
-      disabled={!isLogged}
+      disabled={!isLogged || isMarketFinal(market)}
     >
       {currency === USDC ? USDCIcon : EthIcon}
       {`Create this market in ${currency}`}

--- a/packages/simplified/src/modules/common/tables.tsx
+++ b/packages/simplified/src/modules/common/tables.tsx
@@ -22,6 +22,7 @@ import {
   Formatter,
   ContractCalls,
   Components,
+  Stores,
 } from "@augurproject/comps";
 import getUSDC from "../../utils/get-usdc";
 const {
@@ -49,6 +50,9 @@ const {
   TABLES,
   TransactionTypes,
 } = Constants;
+const {
+  Utils: { isMarketFinal },
+} = Stores;
 
 interface PositionsTableProps {
   market: MarketInfo;
@@ -401,6 +405,7 @@ export const LiquidityFooter = ({ market }: { market: MarketInfo }) => {
   const {
     actions: { setModal },
   } = useAppStatusStore();
+  const isfinal = isMarketFinal(market);
   return (
     <div className={Styles.LiquidityFooter}>
       <PrimaryButton
@@ -416,8 +421,9 @@ export const LiquidityFooter = ({ market }: { market: MarketInfo }) => {
       />
       <SecondaryButton
         text="add liquidity"
+        disabled={isfinal}
         action={() =>
-          setModal({
+          !isfinal && setModal({
             type: MODAL_ADD_LIQUIDITY,
             market,
             currency: market?.amm?.cash?.name,

--- a/packages/simplified/src/modules/markets/markets-view.tsx
+++ b/packages/simplified/src/modules/markets/markets-view.tsx
@@ -82,9 +82,6 @@ const applyFiltersAndSort = (
     if (showLiquidMarkets && (!market.amm || !market.amm.hasLiquidity)) {
       return false;
     }
-    // if (market.isInvalid) {
-    //   return false;
-    // }
     if (
       primaryCategory !== ALL_MARKETS &&
       primaryCategory !== OTHER &&
@@ -122,6 +119,7 @@ const applyFiltersAndSort = (
   updatedFilteredMarkets = updatedFilteredMarkets.sort((marketA, marketB) => {
     const aTransactions = transactions ? transactions[marketA.marketId] : {};
     const bTransactions = transactions ? transactions[marketB.marketId] : {};
+    const mod = reportingState === RESOLVED ? -1 : 1;
     if (sortBy === TOTAL_VOLUME) {
       return (bTransactions?.volumeTotalUSD || 0) > (aTransactions?.volumeTotalUSD || 0) ? 1 : -1;
     } else if (sortBy === TWENTY_FOUR_HOUR_VOLUME) {
@@ -129,7 +127,7 @@ const applyFiltersAndSort = (
     } else if (sortBy === LIQUIDITY) {
       return (Number(marketB?.amm?.liquidityUSD) || 0) > (Number(marketA?.amm?.liquidityUSD) || 0) ? 1 : -1;
     } else if (sortBy === STARTS_SOON) {
-      return marketA?.startTimestamp > marketB?.startTimestamp ? 1 : -1;
+      return (marketA?.startTimestamp > marketB?.startTimestamp ? 1 : -1) * mod;
     }
     return true;
   });


### PR DESCRIPTION
disables add liquidity buttons if a market is resolved already.

don't pop up the add liquidity modal from a market card if the market is resolved.

change sort for Start Time > Resolved Only markets to show the most recently started markets at the top, instead of chronologically ascending order like open markets.