### PR TITLE
More resolution touching

### DIFF
--- a/packages/simplified/src/modules/common/tables.tsx
+++ b/packages/simplified/src/modules/common/tables.tsx
@@ -470,6 +470,7 @@ export const LiquidityTable = ({ market, singleMarket, ammExchange, lpTokens }: 
   const { transactions } = useDataStore();
   const lpAmounts = getUserLpTokenInitialAmount(transactions, account, ammExchange.cash);
   const initCostUsd = lpAmounts[market?.marketId.toLowerCase()];
+  const isfinal = isMarketFinal(market);
   return (
     <div className={Styles.LiquidityTable}>
       {!singleMarket && <MarketTableHeader market={market} ammExchange={ammExchange} />}
@@ -488,8 +489,8 @@ export const LiquidityTable = ({ market, singleMarket, ammExchange, lpTokens }: 
                 });
               }
             }}
-            disabled={!isLogged}
-            text="Earn fees as a liquidity provider"
+            disabled={!isLogged || isfinal}
+            text={isfinal ? "Market is resolved" : "Earn fees as a liquidity provider"}
           />
         </span>
       )}

--- a/packages/simplified/src/modules/common/tables.tsx
+++ b/packages/simplified/src/modules/common/tables.tsx
@@ -409,7 +409,7 @@ export const LiquidityFooter = ({ market }: { market: MarketInfo }) => {
   return (
     <div className={Styles.LiquidityFooter}>
       <PrimaryButton
-        text="remove liquidity"
+        text="Remove Liquidity"
         action={() =>
           setModal({
             type: MODAL_ADD_LIQUIDITY,
@@ -420,7 +420,7 @@ export const LiquidityFooter = ({ market }: { market: MarketInfo }) => {
         }
       />
       <SecondaryButton
-        text="add liquidity"
+        text={isfinal ? "Market Resolved" : "Add Liquidity"}
         disabled={isfinal}
         action={() =>
           !isfinal && setModal({

--- a/packages/simplified/src/modules/market/market-view.tsx
+++ b/packages/simplified/src/modules/market/market-view.tsx
@@ -17,6 +17,7 @@ import {
   Components,
   DerivedMarketData,
   ProcessData,
+  Stores,
 } from "@augurproject/comps";
 import type { MarketInfo, AmmOutcome, MarketOutcome } from "@augurproject/comps/build/types";
 import { MARKETS_LIST_HEAD_TAGS } from "../seo-config";
@@ -34,6 +35,7 @@ const {
 const { getSportsResolutionRules } = DerivedMarketData;
 // eslint-disable-next-line
 const { MARKET_STATUS, YES_NO, BUY, MARKET_ID_PARAM_NAME, DefaultMarketOutcomes } = Constants;
+const { Utils: { isMarketFinal } } = Stores;
 const {
   DateUtils: { getMarketEndtimeFull },
   Formatter: { formatDai },
@@ -161,6 +163,7 @@ const MarketView = ({ defaultMarket = null }) => {
   const winningOutcome = market.amm?.ammOutcomes?.find((o) => o.id === winner);
   const marketTransactions = getCombinedMarketTransactionsFormatted(transactions, market, cashes);
   const { volume24hrTotalUSD = null, volumeTotalUSD = null } = transactions[marketId] || {};
+  const isFinalized = isMarketFinal(market);
   return (
     <div className={Styles.MarketView}>
       <SEO {...MARKETS_LIST_HEAD_TAGS} title={description} ogTitle={description} twitterTitle={description} />
@@ -176,7 +179,7 @@ const MarketView = ({ defaultMarket = null }) => {
         {!!title && <h1>{title}</h1>}
         {!!description && <h2>{description}</h2>}
         {!!startTimestamp && <span>{getMarketEndtimeFull(startTimestamp, timeFormat)}</span>}
-        {reportingState === MARKET_STATUS.FINALIZED && winningOutcome && (
+        {isFinalized && winningOutcome && (
           <WinningOutcomeLabel winningOutcome={winningOutcome} />
         )}
         <ul className={Styles.StatsRow}>
@@ -212,7 +215,7 @@ const MarketView = ({ defaultMarket = null }) => {
         <SimpleChartSection {...{ market, cash: amm?.cash, transactions: marketTransactions, timeFormat }} />
         <PositionsLiquidityViewSwitcher ammExchange={amm} />
         <article className={Styles.MobileLiquidSection}>
-          <AddLiquidity market={market} />
+        {!isFinalized && <AddLiquidity market={market} />}
         </article>
         <div
           className={classNames(Styles.Details, {
@@ -242,7 +245,7 @@ const MarketView = ({ defaultMarket = null }) => {
         })}
       >
         <TradingForm initialSelectedOutcome={selectedOutcome} amm={amm} />
-        <AddLiquidity market={market} />
+        {!isFinalized && <AddLiquidity market={market} />}
       </section>
     </div>
   );


### PR DESCRIPTION
found a spot I missed before to disable add liquidity modal.

updated language for 2 buttons for resolved markets.

hide the add liquidity button on trading page completely if market is resolved.