### PR TITLE
fix-filters-blowup

### DIFF
--- a/packages/comps/src/utils/constants.ts
+++ b/packages/comps/src/utils/constants.ts
@@ -271,13 +271,6 @@ export const NULL_ADDRESS: string = "0x0000000000000000000000000000000000000000"
 export const MODAL_ADD_LIQUIDITY: string = "MODAL_ADD_LIQUIDITY";
 export const MODAL_CONNECT_WALLET: string = "MODAL_CONNECT_WALLET";
 
-export const DEFAULT_MARKET_VIEW_SETTINGS = {
-  categories: ALL_MARKETS,
-  reportingState: OPEN,
-  sortBy: TOTAL_VOLUME,
-  currency: ALL_CURRENCIES,
-};
-
 export const CREATE: string = "create";
 
 export const DefaultMarketOutcomes = [

--- a/packages/simplified/src/modules/markets/markets-view.tsx
+++ b/packages/simplified/src/modules/markets/markets-view.tsx
@@ -3,6 +3,7 @@ import Styles from "./markets-view.styles.less";
 import { AppViewStats, NetworkMismatchBanner } from "../common/labels";
 import classNames from "classnames";
 import { useSimplifiedStore } from "../stores/simplified";
+import { DEFAULT_MARKET_VIEW_SETTINGS } from '../constants';
 import { TopBanner } from "../common/top-banner";
 import {
   useAppStatusStore,
@@ -36,7 +37,6 @@ const {
   POPULAR_CATEGORIES_ICONS,
   sortByItems,
   TOTAL_VOLUME,
-  DEFAULT_MARKET_VIEW_SETTINGS,
   STARTS_SOON,
   RESOLVED,
   IN_SETTLEMENT,

--- a/packages/simplified/src/modules/sidebar/sidebar.tsx
+++ b/packages/simplified/src/modules/sidebar/sidebar.tsx
@@ -10,12 +10,12 @@ import {
   Components,
   useAppStatusStore,
 } from '@augurproject/comps';
+import { DEFAULT_MARKET_VIEW_SETTINGS } from '../constants';
 import { useSimplifiedStore } from '../stores/simplified';
 const {
   MARKETS,
   PORTFOLIO,
   SIDEBAR_TYPES,
-  DEFAULT_MARKET_VIEW_SETTINGS,
   categoryItems,
   // currencyItems,
   marketStatusItems,
@@ -56,7 +56,7 @@ const FilterSideBar = () => {
     JSON.stringify(localSettings) ===
     JSON.stringify(DEFAULT_MARKET_VIEW_SETTINGS);
 
-  return (
+    return (
     <>
       <SideBarHeader header={'filters'} />
       <div className={Styles.Body}>

--- a/packages/sport/src/modules/markets/markets-view.tsx
+++ b/packages/sport/src/modules/markets/markets-view.tsx
@@ -14,7 +14,7 @@ import {
   getCategoryIconLabel,
 } from "@augurproject/comps";
 import type { MarketInfo } from "@augurproject/comps/build/types";
-
+import { DEFAULT_MARKET_VIEW_SETTINGS } from '../constants';
 import { MARKETS_LIST_HEAD_TAGS } from "../seo-config";
 const {
   SelectionComps: { SquareDropdown },
@@ -36,7 +36,6 @@ const {
   POPULAR_CATEGORIES_ICONS,
   sortByItems,
   TOTAL_VOLUME,
-  DEFAULT_MARKET_VIEW_SETTINGS,
   STARTS_SOON,
   RESOLVED,
   IN_SETTLEMENT,


### PR DESCRIPTION
removed confusing comps version of markets view settings, will only use app specific version