### PR TITLE
stops minting shares on market is resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   "private": true,
   "devDependencies": {
     "@types/chai": "^4.2.15",
+    "@types/chai-as-promised": "^7.1.4",
     "@types/mocha": "^8.2.1",
     "@types/node": "^14.14.35",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.19.0",
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^7.22.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-promise": "^4.3.1",

--- a/packages/smart/contracts/turbo/AbstractMarketFactory.sol
+++ b/packages/smart/contracts/turbo/AbstractMarketFactory.sol
@@ -123,6 +123,7 @@ abstract contract AbstractMarketFactory is TurboShareTokenFactory, Ownable {
         address _receiver
     ) public {
         require(markets.length > _id, "No such market");
+        require(!isMarketResolved(_id), "Cannot mint shares for resolved market");
 
         uint256 _cost = calcCost(_shareToMint);
         collateral.transferFrom(msg.sender, address(this), _cost);

--- a/packages/smart/test/turbo-test.ts
+++ b/packages/smart/test/turbo-test.ts
@@ -28,6 +28,7 @@ describe("Turbo", () => {
   let signer: SignerWithAddress;
   const BONE = BigNumber.from(10).pow(18);
   const INITIAL_LP_DUST_BURNT = BONE.div(1000);
+  const FAKE_ADDRESS = "0xFA0E00000000000000000000000000000000FA0E";
 
   before(async () => {
     [signer] = await ethers.getSigners();
@@ -202,8 +203,18 @@ describe("Turbo", () => {
     expect(balances.length).to.equal(5);
   });
 
-  it("can claim winnings", async () => {
+  it("can resolve markets", async () => {
     await marketFactory.trustedResolveMarket(marketId, 1);
+  });
+
+  it("can remove liquidity", async () => {
+    const lpTokens = await ammFactory.getPoolTokenBalance(marketFactory.address, marketId, signer.address);
+    await pool.approve(ammFactory.address, lpTokens);
+    await ammFactory.removeLiquidity(marketFactory.address, marketId, lpTokens, 0, FAKE_ADDRESS);
+    expect(await collateral.balanceOf(FAKE_ADDRESS)).to.equal(1001842805); // hardcoded from observation
+  });
+
+  it("can claim winnings", async () => {
     // can burn non-winning shares
     const setsLeft = await noContest.balanceOf(signer.address);
     await noContest.transfer(DEAD_ADDRESS, setsLeft);

--- a/packages/smart/test/turbo-test.ts
+++ b/packages/smart/test/turbo-test.ts
@@ -1,6 +1,9 @@
 import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
-import { expect } from "chai";
+import { expect, use as chaiUse } from "chai";
+
+import chaiAsPromised from "chai-as-promised";
+chaiUse(chaiAsPromised);
 
 import {
   AMMFactory,
@@ -219,6 +222,17 @@ describe("Turbo", () => {
     expect(await many.balanceOf(signer.address)).to.equal(0);
     expect(await few.balanceOf(signer.address)).to.equal(0);
     expect(await none.balanceOf(signer.address)).to.equal(0);
+  });
+
+  it("cannot mint sets after market resolution", async () => {
+    const setsToMint = shareFactor.mul(100);
+    const costToMint = setsToMint.div(shareFactor);
+
+    await collateral.faucet(costToMint);
+    await collateral.approve(marketFactory.address, costToMint);
+    await expect(marketFactory.mintShares(marketId, setsToMint, signer.address)).to.be.rejectedWith(
+      "VM Exception while processing transaction: revert Cannot mint shares for resolved market"
+    );
   });
 
   it("can create a test balancer pool", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4693,6 +4693,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/chai-as-promised@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz#caf64e76fb056b8c8ced4b761ed499272b737601"
+  integrity sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==
+  dependencies:
+    "@types/chai" "*"
+
 "@types/chai@*", "@types/chai@^4.2.15":
   version "4.2.15"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.15.tgz#b7a6d263c2cecf44b6de9a051cf496249b154553"
@@ -8188,6 +8195,13 @@ cbor@^5.1.0:
   dependencies:
     bignumber.js "^9.0.1"
     nofilter "^1.0.4"
+
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
 
 chai@^4.3.4:
   version "4.3.4"


### PR DESCRIPTION
This stops collateral-shares trading when the market resolves, as well as adding liquidity. But users can still trade shares to shares at the bpool directly so this doesn't completely close the #492 ticket.