### PR TITLE
contracts: add a half point to spread and overunder if the lines are whole numbers

### DIFF
--- a/packages/smart/contracts/turbo/SportsLinkMarketFactory.sol
+++ b/packages/smart/contracts/turbo/SportsLinkMarketFactory.sol
@@ -181,6 +181,15 @@ contract SportsLinkMarketFactory is AbstractMarketFactory {
         _outcomes[1] = "Away";
         _outcomes[2] = "Home";
 
+        // The spread is a quantity of tenths. So 55 is 5.5 and -6 is -60.
+        // If the spread is a whole number then make it a half point more extreme, to eliminate ties.
+        // So 50 becomes 55, -60 becomes -65, and 0 becomes 5.
+        if (_homeSpread >= 0 && _homeSpread % 10 == 0) {
+            _homeSpread += 5;
+        } else if (_homeSpread < 0 && (-_homeSpread) % 10 == 0) {
+            _homeSpread -= 5;
+        }
+
         uint256 _id = markets.length;
         markets.push(makeMarket(_creator, _outcomes, _outcomes, _endTime));
         marketDetails[_id] = MarketDetails(
@@ -219,6 +228,13 @@ contract SportsLinkMarketFactory is AbstractMarketFactory {
         _outcomes[0] = "No Contest";
         _outcomes[1] = "Over";
         _outcomes[2] = "Under";
+
+        // The total is a quantity of tenths. So 55 is 5.5 and -6 is -60.
+        // If the total is a whole number then make it a half point higher, to eliminate ties.
+        // So 50 becomes 55 and 0 becomes 5.
+        if (_overUnderTotal >= 0 &&_overUnderTotal % 10 == 0) {
+            _overUnderTotal += 5;
+        }
 
         uint256 _id = markets.length;
         markets.push(makeMarket(_creator, _outcomes, _outcomes, _endTime));

--- a/packages/smart/contracts/turbo/SportsLinkMarketFactory.sol
+++ b/packages/smart/contracts/turbo/SportsLinkMarketFactory.sol
@@ -232,7 +232,7 @@ contract SportsLinkMarketFactory is AbstractMarketFactory {
         // The total is a quantity of tenths. So 55 is 5.5 and -6 is -60.
         // If the total is a whole number then make it a half point higher, to eliminate ties.
         // So 50 becomes 55 and 0 becomes 5.
-        if (_overUnderTotal >= 0 &&_overUnderTotal % 10 == 0) {
+        if (_overUnderTotal >= 0 && _overUnderTotal % 10 == 0) {
             _overUnderTotal += 5;
         }
 

--- a/packages/smart/test/link-factory-test.ts
+++ b/packages/smart/test/link-factory-test.ts
@@ -23,8 +23,8 @@ describe("LinkFactory", () => {
   const eventId = 9001;
   const homeTeamId = 42;
   const awayTeamId = 1881;
-  const homeSpread = 4;
-  const overUnderTotal = 13;
+  const homeSpread = 40;
+  const overUnderTotal = 60;
   const sportId = 4;
 
   const now = BigNumber.from(Date.now()).div(1000);
@@ -110,6 +110,9 @@ describe("LinkFactory", () => {
     expect(await away.name()).to.equal("Away");
     expect(await home.symbol()).to.equal("Home");
     expect(await home.name()).to.equal("Home");
+
+    const details = await marketFactory.getMarketDetails(spreadMarketId);
+    expect(details.value0).to.equal(homeSpread + 5); // add 5 to avoid a round number
   });
 
   it("over under market is correct", async () => {
@@ -123,11 +126,14 @@ describe("LinkFactory", () => {
     expect(await under.name()).to.equal("Under");
     expect(await over.symbol()).to.equal("Over");
     expect(await over.name()).to.equal("Over");
+
+    const details = await marketFactory.getMarketDetails(overUnderMarketId);
+    expect(details.value0).to.equal(overUnderTotal + 5);
   });
 
   it("can resolve markets", async () => {
     await marketFactory.trustedResolveMarkets(
-      await marketFactory.encodeResolution(eventId, SportsLinkEventStatus.Final, 10, 2)
+      await marketFactory.encodeResolution(eventId, SportsLinkEventStatus.Final, 100, 20)
     );
 
     const headToHeadMarket = await marketFactory.getMarket(headToHeadMarketId);
@@ -137,7 +143,7 @@ describe("LinkFactory", () => {
     expect(spreadMarket.winner).to.equal(spreadMarket.shareTokens[2]); // home spread greater
 
     const overUnderMarket = await marketFactory.getMarket(overUnderMarketId);
-    expect(overUnderMarket.winner).to.equal(overUnderMarket.shareTokens[2]); // under
+    expect(overUnderMarket.winner).to.equal(overUnderMarket.shareTokens[1]); // over
   });
 
   it("encodes and decodes market creation payload", async () => {
@@ -152,7 +158,7 @@ describe("LinkFactory", () => {
       true,
       true
     );
-    expect(payload).to.equal("0x00000000000000000000000000002329002a0759608b53090004000d03000000");
+    expect(payload).to.equal("0x00000000000000000000000000002329002a0759608b53090028003c03000000");
 
     const decoded = await marketFactory.decodeCreation(payload);
     expect(decoded._eventId, "_eventId").to.equal(eventId);


### PR DESCRIPTION
These are the contract changes needed for #637. I don't know if any UI changes are necessary but these contract changes mean the UI doesn't need to alter scores shown to clarify how ties are resolved so there's some work there.