### PR TITLE
fix calculating APY issue when only liquidity dust exits.

### DIFF
--- a/packages/comps/src/utils/contract-calls.ts
+++ b/packages/comps/src/utils/contract-calls.ts
@@ -1180,7 +1180,7 @@ export const calculateAmmTotalVolApy = (
     ? null
     : totalFeesInUsd.div(new BN(liquidityUSD)).div(new BN(pastDays || 1));
 
-  const tradeFeePerDayInYear = hasWinner
+  const tradeFeePerDayInYear = hasWinner || !tradeFeeLiquidityPerDay
     ? undefined
     : tradeFeeLiquidityPerDay.times(DAYS_IN_YEAR).abs().times(100).toFixed(4);
   return { apy: tradeFeePerDayInYear, vol: volumeTotalUSD, vol24hr: volumeTotalUSD24hr };

--- a/packages/comps/src/utils/contract-calls.ts
+++ b/packages/comps/src/utils/contract-calls.ts
@@ -1180,9 +1180,10 @@ export const calculateAmmTotalVolApy = (
     ? null
     : totalFeesInUsd.div(new BN(liquidityUSD)).div(new BN(pastDays || 1));
 
-  const tradeFeePerDayInYear = hasWinner || !tradeFeeLiquidityPerDay
-    ? undefined
-    : tradeFeeLiquidityPerDay.times(DAYS_IN_YEAR).abs().times(100).toFixed(4);
+  const tradeFeePerDayInYear =
+    hasWinner || !tradeFeeLiquidityPerDay
+      ? undefined
+      : tradeFeeLiquidityPerDay.times(DAYS_IN_YEAR).abs().times(100).toFixed(4);
   return { apy: tradeFeePerDayInYear, vol: volumeTotalUSD, vol24hr: volumeTotalUSD24hr };
 };
 


### PR DESCRIPTION
Dash should be displayed in market card. 

![image](https://user-images.githubusercontent.com/3970376/119760743-261d4880-be70-11eb-8b7d-288f144c7b00.png)
