### PR TITLE
Filter resolved non liquid markets

### DIFF
--- a/packages/comps/src/stores/data.tsx
+++ b/packages/comps/src/stores/data.tsx
@@ -41,7 +41,7 @@ export const DataProvider = ({ children }: any) => {
       try {
         const { account: userAccount, loginAccount } = UserStore.get();
         const provider = loginAccount?.library ? loginAccount?.library : defaultProvider?.current;
-        return await getMarketInfos(provider, DataStore.get().markets, cashes, userAccount);
+        return await getMarketInfos(provider, DataStore.get().markets, DataStore.get().ammExchanges, cashes, userAccount);
       } catch (e) {
         console.log("error getting market data", e);
       }

--- a/packages/comps/src/types.ts
+++ b/packages/comps/src/types.ts
@@ -277,6 +277,8 @@ export interface MarketInfo {
   numTicks: string;
   hasWinner: boolean;
   winner?: number;
+  winningShareToken: string;
+  winnerTotalSupply?: string;
 }
 
 export interface MarketOutcome {

--- a/packages/comps/src/utils/constants.ts
+++ b/packages/comps/src/utils/constants.ts
@@ -39,6 +39,7 @@ export const DEFAULT_AMM_FEE_RAW: string = "15000000000000000";
 export const DUST_POSITION_AMOUNT: BigNumber = createBigNumber("0.0001");
 export const DUST_POSITION_AMOUNT_ON_CHAIN: BigNumber = DUST_POSITION_AMOUNT.times(createBigNumber(10).pow(18));
 export const DUST_LIQUIDITY_AMOUNT: BigNumber = createBigNumber("1");
+export const DUST_CLAIMABLE_AMOUNT_ON_CHAIN: BigNumber = DUST_LIQUIDITY_AMOUNT.times(createBigNumber(10).pow(18));
 
 export const ETHER: BigNumber = createBigNumber(10).pow(18);
 export const GWEI_CONVERSION: number = 1000000000;


### PR DESCRIPTION
Only initially load resolved markets, keep open markets up to date. 