### PR TITLE
Update pin-release-on-ipfs.sh

### DIFF
--- a/scripts/pin-release-on-ipfs.sh
+++ b/scripts/pin-release-on-ipfs.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 # Found: https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
-VERSION=$(curl --silent "https://api.github.com/repos/AugurProject/turbo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/');
+CURRENT_VERSION=$(curl --silent "https://api.github.com/repos/AugurProject/turbo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/');
+VERSION="${VERSION:-$CURRENT_VERSION}"
 curl -OL "https://github.com/AugurProject/turbo/releases/download/$VERSION/release.tar.gz";
 
 tar -xzf release.tar.gz;
@@ -14,5 +15,3 @@ echo "CIDv1: $IPFS_HASH_CIDv1";
 
 rm -rf build;
 rm release.tar.gz;
-
-


### PR DESCRIPTION
Allow specifying a specific version to pin with VERSION environment varaible. Fall back to latest.