### PR TITLE
Fix making bet check allowance

### DIFF
--- a/packages/sport/src/modules/App.tsx
+++ b/packages/sport/src/modules/App.tsx
@@ -21,7 +21,6 @@ import {
 import { Betslip } from "./betslip/betslip";
 import { BetslipProvider } from './stores/betslip';
 import { SportsFooter } from './common/sports-footer';
-import { useActiveBets } from "./stores/betslip-hooks";
 
 const { PORTFOLIO, MARKET_LOAD_TYPE } = Constants;
 const { parsePath } = PathUtils;
@@ -37,7 +36,6 @@ const AppBody = () => {
 
   useUserBalances({ ammExchanges, blocknumber, cashes, markets, transactions });
   useFinalizeUserTransactions(blocknumber);
-  useActiveBets(blocknumber)
   
   useEffect(() => {
     const html: any = windowRef.document.firstElementChild;

--- a/packages/sport/src/modules/betslip/betslip.tsx
+++ b/packages/sport/src/modules/betslip/betslip.tsx
@@ -361,10 +361,8 @@ const BetReciept = ({ tx_hash, bet }: { tx_hash: string, bet: ActiveBetType }) =
   } = useBetslipStore();
   const { 
     loginAccount,
-    transactions, 
     actions: { addTransaction } } = useUserStore();
-  const { price, name, heading, isApproved, canCashOut, isPending } = bet;
-  const status = transactions.find((t) => t.hash === tx_hash)?.status || TX_STATUS.CONFIRMED;
+  const { price, name, heading, isApproved, canCashOut, isPending, status } = bet;
   const market = markets[bet.marketId];
   const txStatus = {
     message: null,
@@ -402,8 +400,11 @@ const BetReciept = ({ tx_hash, bet }: { tx_hash: string, bet: ActiveBetType }) =
   const doApproveOrCashOut = async (loginAccount, bet, market) => {
     const txDetails = await approveOrCashOut(loginAccount, bet, market);
     if (txDetails?.hash) {
+      console.log(txDetails);
       addTransaction(txDetails);
-      updateActive({...bet, hash: txDetails.hash}, true)
+      const newBet = {...bet, hash: txDetails.hash};
+      console.log(bet.hash, newBet.hash); 
+      updateActive(newBet, true)
     }
   }
       

--- a/packages/sport/src/modules/betslip/betslip.tsx
+++ b/packages/sport/src/modules/betslip/betslip.tsx
@@ -400,11 +400,8 @@ const BetReciept = ({ tx_hash, bet }: { tx_hash: string, bet: ActiveBetType }) =
   const doApproveOrCashOut = async (loginAccount, bet, market) => {
     const txDetails = await approveOrCashOut(loginAccount, bet, market);
     if (txDetails?.hash) {
-      console.log(txDetails);
       addTransaction(txDetails);
-      const newBet = {...bet, hash: txDetails.hash};
-      console.log(bet.hash, newBet.hash); 
-      updateActive(newBet, true)
+      updateActive({...bet, hash: txDetails.hash}, true)
     }
   }
       
@@ -525,6 +522,7 @@ const BetslipFooter = () => {
                 if (txDetails.hash) {
                   addActive({
                     ...bet,
+                    betId,
                     ...txDetails,
                   });
                   addTransaction(txDetails);

--- a/packages/sport/src/modules/sports-card/sports-card.tsx
+++ b/packages/sport/src/modules/sports-card/sports-card.tsx
@@ -238,6 +238,7 @@ const ComboOutcomeRow = ({ eventMarkets, eventOutcome, marketEvent, ...props }) 
             addBet({
               ...spreadMarket.amm.ammOutcomes[eventOutcomeId],
               ...spreadSizePrice,
+              outcomeId: eventOutcomeId,
               marketId: spreadMarket.marketId,
               heading: `${marketEvent.description || spreadMarket.description}:`,
               subHeading: `${SPORTS_MARKET_TYPE_LABELS[spreadMarket.sportsMarketType]}`,
@@ -255,6 +256,7 @@ const ComboOutcomeRow = ({ eventMarkets, eventOutcome, marketEvent, ...props }) 
             addBet({
               ...moneyLineMarket.amm.ammOutcomes[eventOutcomeId],
               ...moneyLineSizePrice,
+              outcomeId: eventOutcomeId,
               marketId: moneyLineMarket.marketId,
               heading: `${marketEvent.description || moneyLineMarket.description}:`,
               subHeading: `${SPORTS_MARKET_TYPE_LABELS[moneyLineMarket.sportsMarketType]}`,
@@ -272,6 +274,7 @@ const ComboOutcomeRow = ({ eventMarkets, eventOutcome, marketEvent, ...props }) 
             addBet({
               ...OUMarket.amm.ammOutcomes[eventOutcomeId],
               ...OUSizePrice,
+              outcomeId: eventOutcomeId,
               marketId: OUMarket.marketId,
               heading: `${marketEvent.description || OUMarket.description}:`,
               subHeading: `${SPORTS_MARKET_TYPE_LABELS[OUMarket.sportsMarketType]}`,
@@ -322,6 +325,7 @@ const SportsOutcomeButton = ({ outcome, marketId, description, amm, eventId, spo
             ...outcome,
             ...sizedPrice,
             marketId,
+            outcomeId: id,
             heading: `${marketEvents?.[eventId]?.description || description}:`,
             subHeading: `${SPORTS_MARKET_TYPE_LABELS[sportsMarketType]}`,
           })

--- a/packages/sport/src/modules/stores/betslip-hooks.ts
+++ b/packages/sport/src/modules/stores/betslip-hooks.ts
@@ -4,7 +4,7 @@ import { BETSLIP, ACTIVE_BETS, TX_STATUS } from "../constants";
 import { windowRef, Stores } from "@augurproject/comps";
 import { useUserStore } from "@augurproject/comps";
 import { useBetslipStore } from "./betslip";
-import { estimatedCashOut, isCashOutApproved } from "modules/utils";
+import { isCashOutApproved } from "modules/utils";
 import { useDataStore } from "@augurproject/comps";
 const {
   Utils: { dispatchMiddleware },
@@ -146,15 +146,14 @@ export const useActiveBets = (blocknumber) => {
       Object.keys(active).forEach(async (id) => {
         const activeBet: ActiveBetType = active[id];
         const market = markets[activeBet.marketId];
-        const isApproved = await isCashOutApproved(loginAccount, activeBet, market, transactions);
-        const isPending = Boolean(
-          transactions.find((t) => t.hash === activeBet.hash && t.status === TX_STATUS.PENDING)
-        );
+        const isApproved = await isCashOutApproved(loginAccount, activeBet.outcomeId, market, transactions);
+        const status = transactions.find((t) => t.hash === activeBet.hash)?.status || TX_STATUS.CONFIRMED;
         updateActive(
           {
             ...active[id],
-            isPending,
+            isPending: status === TX_STATUS.PENDING,
             isApproved,
+            status
           },
           true
         );

--- a/packages/sport/src/modules/stores/betslip-hooks.ts
+++ b/packages/sport/src/modules/stores/betslip-hooks.ts
@@ -133,31 +133,3 @@ export const useBetslip = (defaultState = DEFAULT_BETSLIP_STATE) => {
     },
   };
 };
-
-export const useActiveBets = (blocknumber) => {
-  const { account, loginAccount, transactions } = useUserStore();
-  const { markets } = useDataStore();
-  const {
-    active,
-    actions: { updateActive },
-  } = useBetslipStore();
-  useEffect(() => {
-    if (account) {
-      Object.keys(active).forEach(async (id) => {
-        const activeBet: ActiveBetType = active[id];
-        const market = markets[activeBet.marketId];
-        const isApproved = await isCashOutApproved(loginAccount, activeBet.outcomeId, market, transactions);
-        const status = transactions.find((t) => t.hash === activeBet.hash)?.status || TX_STATUS.CONFIRMED;
-        updateActive(
-          {
-            ...active[id],
-            isPending: status === TX_STATUS.PENDING,
-            isApproved,
-            status
-          },
-          true
-        );
-      });
-    }
-  }, [blocknumber, account]);
-};

--- a/packages/sport/src/modules/stores/betslip.tsx
+++ b/packages/sport/src/modules/stores/betslip.tsx
@@ -4,8 +4,8 @@ import { DEFAULT_BETSLIP_STATE, STUBBED_BETSLIP_ACTIONS } from "../stores/consta
 import { useBetslip } from "./betslip-hooks";
 import { useUserStore, useDataStore, Formatter, Constants } from "@augurproject/comps";
 import { useSportsStore } from "./sport";
-import { AmmMarketShares } from "@augurproject/comps/build/types";
-import { estimatedCashOut } from "modules/utils";
+import { AmmMarketShares, PositionBalance } from "@augurproject/comps/build/types";
+import { estimatedCashOut, isCashOutApproved } from "modules/utils";
 import { TX_STATUS } from "modules/constants";
 const { formatDai, isSameAddress } = Formatter;
 const { SPORTS_MARKET_TYPE_LABELS } = Constants;
@@ -20,62 +20,83 @@ export const BetslipStore = {
   actions: STUBBED_BETSLIP_ACTIONS,
 };
 
-const usePersistentActiveBets = ({ active, actions: { updateActive, addActive } }) => {
+const usePersistentActiveBets = ({ active, actions: { updateActive, addActive, removeActive } }) => {
   const { marketEvents } = useSportsStore();
   const {
     account,
     balances: { marketShares },
+    loginAccount,
+    transactions: userTransactions
   } = useUserStore();
-  const { transactions, blocknumber } = useDataStore();
+  const { markets, transactions, blocknumber } = useDataStore();
 
-  useEffect(() => {
+  useEffect(async () => {
     if (!account) return null;
-    const preparedActiveBets = Object.keys(marketShares).reduce((p, marketId) => {
+    const marketPositions = Object.keys(marketShares).reduce((p, marketId) => {
       const userMarketShares = marketShares as AmmMarketShares;
       const marketPositions = userMarketShares[marketId];
       const { market } = marketPositions.ammExchange;
       if (market.hasWinner) return p;
-      const bets = marketPositions.positions.map(position => {
-        const marketTrades = transactions?.[marketId]?.trades;
-        const mostRecentUserTrade = marketTrades
-          ?.filter((t) => isSameAddress(t.user, account))
-          ?.filter((ut) => new BN(position.outcomeId).eq(new BN(ut.outcome)))
-          .sort((a, b) => Number(a.timestamp) - Number(b.timestamp))[0];
-        const marketEvent = marketEvents[market.eventId];
-        const toWin = new BN(position.quantity).minus(new BN(position.initCostUsd));
-        const { name } = market.outcomes.find(outcome => outcome.id === position.outcomeId);
-        const cashoutAmount = estimatedCashOut(market.amm, position.quantity, position.outcomeId);
 
-        return {
-          heading: `${marketEvent?.description}`,
-          subHeading: `${SPORTS_MARKET_TYPE_LABELS[market.sportsMarketType]}`,
-          name,
-          price: position.avgPrice,
-          wager: formatDai(position.initCostUsd).formatted,
-          toWin: formatDai(toWin).formatted,
-          timestamp: mostRecentUserTrade ? mostRecentUserTrade?.timestamp : null,
-          hash: mostRecentUserTrade ? mostRecentUserTrade?.transactionHash : null,
-          betId: `${market.marketId}-${position.outcomeId}`,
-          marketId: market.marketId,
-          size: position.quantity,
-          outcomeId: position.outcomeId,
-          cashoutAmount,
-          canCashOut: cashoutAmount !== null,
-          status: TX_STATUS.CONFIRMED
-        };
-      });
-      return [...p, ...bets];
+      return [...p, ...marketPositions.positions.map(pos => ({ ...pos, marketId: market.marketId }))];
     }, []);
 
-    if (preparedActiveBets.length) {
-      preparedActiveBets.forEach((bet) => {
+    const bets = [];
+    for (let i = 0; i < marketPositions.length; i++) {
+      const position = marketPositions[i];
+      const marketId = position.marketId
+      const market = markets[marketId];
+      const marketTrades = transactions?.[marketId]?.trades;
+      const mostRecentUserTrade = marketTrades
+        ?.filter((t) => isSameAddress(t.user, account))
+        ?.filter((ut) => new BN(position.outcomeId).eq(new BN(ut.outcome)))
+        .sort((a, b) => Number(a.timestamp) - Number(b.timestamp))[0];
+      const marketEvent = marketEvents[market.eventId];
+      const toWin = new BN(position.quantity).minus(new BN(position.initCostUsd));
+      const { name } = market.outcomes.find(outcome => outcome.id === position.outcomeId);
+      const cashoutAmount = estimatedCashOut(market.amm, position.quantity, position.outcomeId);
+      const isApproved = await isCashOutApproved(loginAccount, position.outcomeId, market, transactions);
+      const betId = `${market.marketId}-${position.outcomeId}`;
+      const activeBet = active[betId];
+      const status = userTransactions.find((t) => t.hash === activeBet?.hash)?.status || TX_STATUS.CONFIRMED;
+
+      bets.push({
+        heading: `${marketEvent?.description}`,
+        subHeading: `${SPORTS_MARKET_TYPE_LABELS[market.sportsMarketType]}`,
+        name,
+        price: position.avgPrice,
+        wager: formatDai(position.initCostUsd).formatted,
+        toWin: formatDai(toWin).formatted,
+        timestamp: mostRecentUserTrade ? mostRecentUserTrade?.timestamp : null,
+        hash: mostRecentUserTrade ? mostRecentUserTrade?.transactionHash : null,
+        betId,
+        marketId: market.marketId,
+        size: position.quantity,
+        outcomeId: position.outcomeId,
+        cashoutAmount,
+        canCashOut: cashoutAmount !== null,
+        isPending: status === TX_STATUS.PENDING,
+        isApproved,
+        status,
+      });
+    }
+
+
+    // remove cashed out bets
+    const keys = bets.map(b => b.betId);
+    const betIds = Object.keys(active).filter(betId => active[betId].status !== TX_STATUS.PENDING)
+      .filter(betId => !keys.includes(betId));
+    betIds.map(betId => removeActive(betId));
+
+    if (bets.length) {
+      bets.forEach((bet) => {
         active[bet.betId] ? updateActive(bet, true) : addActive(bet, true);
       });
     }
   }, [account, blocknumber]);
 };
 
-const useClearOnLogout = ({ actions: { clearBetslip }}) => {
+const useClearOnLogout = ({ actions: { clearBetslip } }) => {
   const { account } = useUserStore();
 
   useEffect(() => {

--- a/packages/sport/src/modules/stores/betslip.tsx
+++ b/packages/sport/src/modules/stores/betslip.tsx
@@ -6,6 +6,7 @@ import { useUserStore, useDataStore, Formatter, Constants } from "@augurproject/
 import { useSportsStore } from "./sport";
 import { AmmMarketShares } from "@augurproject/comps/build/types";
 import { estimatedCashOut } from "modules/utils";
+import { TX_STATUS } from "modules/constants";
 const { formatDai, isSameAddress } = Formatter;
 const { SPORTS_MARKET_TYPE_LABELS } = Constants;
 export const BetslipContext = React.createContext({
@@ -60,6 +61,7 @@ const usePersistentActiveBets = ({ active, actions: { updateActive, addActive } 
           outcomeId: position.outcomeId,
           cashoutAmount,
           canCashOut: cashoutAmount !== null,
+          status: TX_STATUS.CONFIRMED
         };
       });
       return [...p, ...bets];

--- a/packages/sport/src/modules/stores/constants.ts
+++ b/packages/sport/src/modules/stores/constants.ts
@@ -89,6 +89,7 @@ export interface ActiveBetType {
   isApproved: boolean;
   cashoutAmount: string;
   isPending: boolean;
+  status: string;
 }
 
 export const DEFAULT_BET = {

--- a/packages/sport/src/modules/utils/index.ts
+++ b/packages/sport/src/modules/utils/index.ts
@@ -166,9 +166,9 @@ export const isCashOutApproved = async (
   market: MarketInfo,
   transactions: TransactionDetails[]
 ): Promise<Boolean> => {
-  const { amm } = market;
+  if (!market) return false;
   const shareToken = market.shareTokens[outcomeId];
-  const result = await checkAllowance(shareToken, amm.ammFactoryAddress, loginAccount, transactions);
+  const result = await checkAllowance(shareToken, market?.amm.ammFactoryAddress, loginAccount, transactions);
   return result === ApprovalState.APPROVED;
 };
 

--- a/packages/sport/src/modules/utils/index.ts
+++ b/packages/sport/src/modules/utils/index.ts
@@ -7,7 +7,7 @@ import { claimWinnings } from "@augurproject/comps/build/utils/contract-calls";
 import { ActiveBetType } from "modules/stores/constants";
 import { MarketInfo } from "@augurproject/comps/build/types";
 import { approveERC20Contract, checkAllowance } from "@augurproject/comps/build/stores/use-approval-callback";
-import { ApprovalState } from "modules/constants";
+import { ApprovalState, TX_STATUS } from "modules/constants";
 const { estimateBuyTrade, estimateSellTrade } = ContractCalls;
 
 export interface SizedPrice {
@@ -45,7 +45,7 @@ export const getBuyAmount = (amm: AmmExchange, id: number, amount: string): BuyA
 };
 
 export const estimatedCashOut = (amm: AmmExchange, size: string, outcomeId: number): string => {
-  if (!amm?.hasLiquidity || !size || !outcomeId) return null;
+  if (!amm?.hasLiquidity || !size || outcomeId === undefined) return null;
   const est = estimateSellTrade(amm, size, outcomeId, []);
   // can sell all position or none
   return est.maxSellAmount !== "0" ? null : est.outputValue;
@@ -82,6 +82,8 @@ const makeCashOut = async (
     seen: false,
     from: loginAccount?.account,
     addedTime: new Date().getTime(),
+    status: TX_STATUS.PENDING,
+    message: "Cashout Bet",
     marketDescription: `${amm?.market?.title} ${amm?.market?.description}`,
   };
 };
@@ -115,6 +117,7 @@ export const makeBet = async (
     seen: false,
     from: account,
     addedTime: new Date().getTime(),
+    status: TX_STATUS.PENDING,
     message: "Bet Placed",
     marketDescription: `${amm?.market?.title} ${amm?.market?.description}`,
   };
@@ -149,6 +152,7 @@ export const claimAll = async (
       seen: false,
       from: loginAccount?.account,
       addedTime: new Date().getTime(),
+      status: TX_STATUS.PENDING,
       message: "Claim Winnings",
       marketDescription: `Claim Winnings`,
     };
@@ -158,11 +162,10 @@ export const claimAll = async (
 
 export const isCashOutApproved = async (
   loginAccount: LoginAccount,
-  bet: ActiveBetType,
+  outcomeId: number,
   market: MarketInfo,
   transactions: TransactionDetails[]
 ): Promise<Boolean> => {
-  const { outcomeId } = bet;
   const { amm } = market;
   const shareToken = market.shareTokens[outcomeId];
   const result = await checkAllowance(shareToken, amm.ammFactoryAddress, loginAccount, transactions);


### PR DESCRIPTION
removed use active hook, put logic in existing `usePersistentActiveBets` since it's monitoring users positions per block. remove non pending active bets that don't have associated user position