### PR TITLE
chunk-multicall

### DIFF
--- a/packages/comps/src/utils/contract-calls.ts
+++ b/packages/comps/src/utils/contract-calls.ts
@@ -1559,7 +1559,7 @@ const retrieveMarkets = async (
       const j = i + 1;
       const chunk = j === totalChunks ? contractMarketsCall.slice(j * 900) : contractMarketsCall.slice(i, j * 900);
       const call = await multicall.call(chunk).catch((e) => {
-        console.error(e);
+        console.error(`retrieveMarkets, chunk ${chunk}`, e);
         throw e;
       });
       combined.blockNumber = call.blockNumber;


### PR DESCRIPTION
taking a crack at chunking larger multicalls. will now call in chunks of 900 if the total amount of calls we need to multi-call exceeds 900. This chunking logic only effects retrieveMarkets.

https://github.com/AugurProject/turbo/issues/845 addresses this.