### PR TITLE
add amm factory approval to user balances

### DIFF
--- a/packages/comps/src/types.ts
+++ b/packages/comps/src/types.ts
@@ -605,6 +605,9 @@ export interface AmmMarketShares {
   };
 }
 
+export interface Approvals {
+  [address: string]: boolean;
+}
 export interface UserBalances {
   ETH: CurrencyBalance;
   USDC: CurrencyBalance;
@@ -619,6 +622,7 @@ export interface UserBalances {
   claimableFees: string;
   rep?: string;
   legacyRep?: string;
+  approvals: Approvals
 }
 
 export interface ProcessedData {

--- a/packages/comps/src/types.ts
+++ b/packages/comps/src/types.ts
@@ -622,7 +622,7 @@ export interface UserBalances {
   claimableFees: string;
   rep?: string;
   legacyRep?: string;
-  approvals: Approvals
+  approvals: Approvals;
 }
 
 export interface ProcessedData {

--- a/packages/comps/src/types.ts
+++ b/packages/comps/src/types.ts
@@ -622,7 +622,7 @@ export interface UserBalances {
   claimableFees: string;
   rep?: string;
   legacyRep?: string;
-  approvals: Approvals;
+  approvals?: Approvals;
 }
 
 export interface ProcessedData {


### PR DESCRIPTION
to be used for sportsbook to show buy approvals needed based on what bets are loaded in betslip. 
approval collection is keyed by amm factory address

![Screen Shot 2021-06-28 at 10 35 40 AM](https://user-images.githubusercontent.com/3970376/123664676-2ad17580-d7fd-11eb-89cd-2146835e8e99.png)
