### PR TITLE
account-n-card-styles

### DIFF
--- a/packages/comps/src/components/ConnectAccount/components/AccountDetails/index.less
+++ b/packages/comps/src/components/ConnectAccount/components/AccountDetails/index.less
@@ -128,6 +128,15 @@
         > button {
           margin-right: @size-8;
         }
+
+        @media @breakpoint-mobile {
+          display: grid;
+          grid-gap: @size-8;
+
+          > button {
+            margin-right: 0;
+          }
+        }
       }
     }
   }

--- a/packages/comps/src/components/market-card/market-card.styles.less
+++ b/packages/comps/src/components/market-card/market-card.styles.less
@@ -77,6 +77,7 @@
       }
     }
 
+    > section > span,
     > a > span,
     > span {
       > span:first-of-type {
@@ -127,7 +128,8 @@
       grid-column: 1 / span 3;
     }
 
-    > a {
+    > a,
+    > section {
       grid-column: 1 / span 3;
       width: 100%;
       min-height: @size-180;
@@ -468,7 +470,8 @@ span.ExtraOutcomes {
         height: unset;
       }
 
-      > a {
+      > a,
+      > section {
         display: flex;
         flex-flow: row wrap;
         justify-content: space-between;
@@ -541,6 +544,7 @@ span.ExtraOutcomes {
 
 @media @breakpoint-mobile-tablet {
   .MarketCard > a > a,
+  .MarketCard > a > section,
   .MarketCard > div > a,
   .MarketCard > div > a > span {
     height: unset;

--- a/packages/comps/src/components/market-card/market-card.tsx
+++ b/packages/comps/src/components/market-card/market-card.tsx
@@ -188,7 +188,7 @@ export const MarketCardView = ({
             )}
           </div>
         </article>
-        <a>
+        <section>
           <MarketTitleArea {...{ ...market, timeFormat }} />
           <ValueLabel label="total volume" value={formattedVol || "-"} />
           <ValueLabel label="Liquidity" value={marketHasNoLiquidity ? "-" : formattedLiquidity || "-"} />
@@ -196,7 +196,7 @@ export const MarketCardView = ({
           {!hasWinner && extraOutcomes > 0 && (
             <span className={Styles.ExtraOutcomes}>{`+ ${extraOutcomes} more Outcomes`}</span>
           )}
-        </a>
+        </section>
       </MarketLink>
     </article>
   );


### PR DESCRIPTION
added style updates for mobile account pop up for both simp and sport, updated market cards in sport to not nest a double a tag as the browser wasn't happy about it