### PR TITLE
ui-tweaks

### DIFF
--- a/packages/sport/src/modules/markets/markets-view.tsx
+++ b/packages/sport/src/modules/markets/markets-view.tsx
@@ -141,6 +141,14 @@ const applyFiltersAndSort = (
       .sort((a, b) => (a?.startTimestamp > b?.startTimestamp ? 1 : -1));
 
     updatedFilteredMarkets = updatedFilteredMarkets.filter((m) => m?.amm?.id !== null).concat(sortedIlliquid);
+  } else {
+    // it is sort by, make sure to put markets that are before now to the end 
+    // of the list and order them with most recently started to oldest market.
+    const date = new Date();
+    const now = Math.floor(date.getTime() / 1000);
+    const beforeNow = updatedFilteredMarkets.filter(m => m.startTimestamp <= now).sort((a, b) => b.startTimestamp - a.startTimestamp);
+    const afterNow = updatedFilteredMarkets.filter(m => m.startTimestamp > now);
+    updatedFilteredMarkets = afterNow.concat(beforeNow);
   }
 
   // TODO: Strip out futures/dailes:

--- a/packages/sport/src/modules/sports-card/sports-card.tsx
+++ b/packages/sport/src/modules/sports-card/sports-card.tsx
@@ -200,7 +200,7 @@ const ComboOutcomeRow = ({ eventMarkets, eventOutcome, marketEvent, ...props }) 
   ]);
   const spreadOdds = useMemo(
     () =>
-      spreadSizePrice
+      spreadSizePrice?.price
         ? convertToOdds(convertToNormalizedPrice({ price: spreadSizePrice.price }), oddsFormat).full
         : "-",
     [spreadSizePrice, oddsFormat]
@@ -211,7 +211,7 @@ const ComboOutcomeRow = ({ eventMarkets, eventOutcome, marketEvent, ...props }) 
   ]);
   const moneyLineOdds = useMemo(
     () =>
-      moneyLineSizePrice
+      moneyLineSizePrice?.price
         ? convertToOdds(convertToNormalizedPrice({ price: moneyLineSizePrice.price }), oddsFormat).full
         : "-",
     [moneyLineSizePrice, oddsFormat]
@@ -221,7 +221,7 @@ const ComboOutcomeRow = ({ eventMarkets, eventOutcome, marketEvent, ...props }) 
     betSizeToOdds,
   ]);
   const OUOdds = useMemo(
-    () => (OUSizePrice ? convertToOdds(convertToNormalizedPrice({ price: OUSizePrice.price }), oddsFormat).full : "-"),
+    () => (OUSizePrice?.price ? convertToOdds(convertToNormalizedPrice({ price: OUSizePrice.price }), oddsFormat).full : "-"),
     [OUSizePrice, oddsFormat]
   );
   const firstOULetter = OUMarket?.amm?.ammOutcomes[eventOutcomeId]?.name.slice(0, 1);
@@ -295,9 +295,9 @@ const ComboOutcomeRow = ({ eventMarkets, eventOutcome, marketEvent, ...props }) 
         )}
         <span>{OUOdds}</span>
       </button>
-      <span>{spreadSizePrice?.size && <span>{formatDai(spreadSizePrice?.size).full}</span>}</span>
-      <span>{moneyLineSizePrice?.size && <span>{formatDai(moneyLineSizePrice?.size).full}</span>}</span>
-      <span>{OUSizePrice?.size && <span>{formatDai(OUSizePrice?.size).full}</span>}</span>
+      <span>{spreadSizePrice?.size && spreadSizePrice?.size !== "0" && <span>{formatDai(spreadSizePrice?.size).full}</span>}</span>
+      <span>{moneyLineSizePrice?.size && moneyLineSizePrice?.size !== "0" && <span>{formatDai(moneyLineSizePrice?.size).full}</span>}</span>
+      <span>{OUSizePrice?.size && OUSizePrice?.size !== "0" && <span>{formatDai(OUSizePrice?.size).full}</span>}</span>
     </article>
   );
 };
@@ -314,7 +314,7 @@ const SportsOutcomeButton = ({ outcome, marketId, description, amm, eventId, spo
   const { id, name } = outcome;
   const sizedPrice = useMemo(() => getSizedPrice(amm, id, betSizeToOdds), [outcome.balance, betSizeToOdds]);
   const odds = useMemo(
-    () => (sizedPrice ? convertToOdds(convertToNormalizedPrice({ price: sizedPrice.price }), oddsFormat).full : "-"),
+    () => (sizedPrice?.price ? convertToOdds(convertToNormalizedPrice({ price: sizedPrice.price }), oddsFormat).full : "-"),
     [sizedPrice, oddsFormat]
   );
   return (
@@ -337,7 +337,7 @@ const SportsOutcomeButton = ({ outcome, marketId, description, amm, eventId, spo
       >
         {odds}
       </button>
-      {sizedPrice?.size && <span>{formatDai(sizedPrice?.size).full}</span>}
+      {sizedPrice?.size && sizedPrice.size !== "0" && <span>{formatDai(sizedPrice?.size).full}</span>}
     </div>
   );
 };


### PR DESCRIPTION
handle bad getSizedPrice situation

tweaked starts soon sorting for sportsbook only. behavior will now check current local time, then split the sorting in half, markets in the future of now will come first in ascending order -- when we run out of markets that are in the future we will then start rendering cards of games that started before right now however the order will be descending instead of ascending. AKA a game that started 20 mins ago will be at the top of the list, instead of at the bottom.