### PR TITLE
resolved-tags-portfolio

### DIFF
--- a/packages/simplified/src/modules/common/tables.styles.less
+++ b/packages/simplified/src/modules/common/tables.styles.less
@@ -22,24 +22,10 @@
     text-decoration: none;
   }
 
-  > a > span[class*='InvalidFlagTipIcon'] {
-    margin-right: @size-8;
-    min-height: @size-20;
-    min-width: @size-20;
-    max-height: @size-20;
-    max-width: @size-20;
-
-    > label > svg {
-      min-height: @size-20;
-      min-width: @size-20;
-      max-height: @size-20;
-      max-width: @size-20;
-    }
-  }
-
   > a > svg {
     width: @size-20;
     height: @size-20;
+    justify-self: flex-end;
   }
 
   > div:last-child {
@@ -51,6 +37,29 @@
 
   @media @breakpoint-mobile-tablet {
     padding: @size-16;
+  }
+
+  @media @breakpoint-mobile {
+    > a {
+      display: grid;
+
+      > span:first-of-type {
+        grid-column: 1;
+        grid-row: span 2;
+        margin: 0;
+      }
+
+      > svg:first-of-type {
+        grid-column: 2;
+        grid-row: 1;
+      }
+
+      > div:first-of-type {
+        grid-column: 2;
+        grid-row: 2;
+        margin: 0;
+      }
+    }
   }
 }
 
@@ -349,7 +358,7 @@
     > a > button {
       flex: 1 100%;
       width: 100%;
-      margin: 0;
+      margin: @size-4 0;
       text-align: center;
     }
 

--- a/packages/simplified/src/modules/common/tables.tsx
+++ b/packages/simplified/src/modules/common/tables.tsx
@@ -27,14 +27,20 @@ import {
 import getUSDC from "../../utils/get-usdc";
 import { useSimplifiedStore } from "../stores/simplified";
 const {
-  LabelComps: { MovementLabel, generateTooltip, WarningBanner },
+  LabelComps: { MovementLabel, generateTooltip, WarningBanner, ReportingStateLabel },
   PaginationComps: { sliceByPage, Pagination },
   ButtonComps: { PrimaryThemeButton, SecondaryThemeButton, TinyThemeButton },
   SelectionComps: { SmallDropdown },
   Links: { AddressLink, MarketLink, ReceiptLink },
   Icons: { EthIcon, UpArrow, UsdIcon },
 } = Components;
-const { claimWinnings, getUserLpTokenInitialAmount, getCompleteSetsAmount, cashOutAllShares, canAddLiquidity } = ContractCalls;
+const {
+  claimWinnings,
+  getUserLpTokenInitialAmount,
+  getCompleteSetsAmount,
+  cashOutAllShares,
+  canAddLiquidity,
+} = ContractCalls;
 const { formatDai, formatCash, formatSimplePrice, formatSimpleShares, formatPercent, formatLiquidity } = Formatter;
 const { timeSinceTimestamp, getMarketEndtimeFull } = DateUtils;
 const {
@@ -49,6 +55,7 @@ const {
   TX_STATUS,
   TABLES,
   TransactionTypes,
+  MARKET_STATUS,
 } = Constants;
 const {
   Utils: { isMarketFinal },
@@ -73,7 +80,7 @@ interface LiquidityTableProps {
 
 const MarketTableHeader = ({
   timeFormat,
-  market: { startTimestamp, title, description, marketId },
+  market: { startTimestamp, title, description, marketId, reportingState },
   ammExchange,
 }: {
   timeFormat: string;
@@ -86,6 +93,7 @@ const MarketTableHeader = ({
         {!!title && <span>{title}</span>}
         {!!description && <span>{description}</span>}
       </span>
+      {reportingState !== MARKET_STATUS.TRADING && <ReportingStateLabel {...{ reportingState }} />}
       {ammExchange.cash.name === USDC ? UsdIcon : EthIcon}
     </MarketLink>
     {!!startTimestamp && <div>{getMarketEndtimeFull(startTimestamp, timeFormat)}</div>}


### PR DESCRIPTION
added resolved tags to portfolio section of turbo, fixed mobile button styling for turbo tables to give some spacing between the buttons vertically

<img width="873" alt="Screen Shot 2021-08-10 at 1 39 13 PM" src="https://user-images.githubusercontent.com/10524630/128916475-4ab09535-b3ee-4869-96ec-e448bc785411.png">
<img width="411" alt="Screen Shot 2021-08-10 at 1 39 29 PM" src="https://user-images.githubusercontent.com/10524630/128916488-bcc125e8-bb0d-408e-b29e-114b33c70338.png">

