### PR TITLE
Futures Tweaks

### DIFF
--- a/packages/smart/src/utils/common-functions.ts
+++ b/packages/smart/src/utils/common-functions.ts
@@ -32,3 +32,7 @@ export type TypeOfClassMethod<T, M extends keyof T> = T[M] extends Function ? T[
 export function repeat<T>(thing: T, n: number): T[] {
   return Array.from({ length: n }).map(() => thing);
 }
+
+export function range(inclusiveMin: number, exclusiveMax: number): number[] {
+  return [...new Array(exclusiveMax - inclusiveMin).keys()].map((i) => i + inclusiveMin);
+}

--- a/packages/smart/tasks/cannedMarkets.ts
+++ b/packages/smart/tasks/cannedMarkets.ts
@@ -8,6 +8,7 @@ import {
   getUpcomingFriday4pmET,
   MarketFactoryType,
   NBAMarketFactory,
+  range,
 } from "..";
 import { ManagedByLink, MMAMarketFactory } from "../typechain";
 import { BigNumber, BigNumberish, ContractReceipt, ContractTransaction, Signer } from "ethers";
@@ -92,10 +93,6 @@ function makeWait(confirmations: number) {
   return (tx: ContractTransaction): Promise<ContractReceipt> => {
     return tx.wait(confirmations);
   };
-}
-
-function range(inclusiveMin: number, exclusiveMax: number): number[] {
-  return [...new Array(exclusiveMax - inclusiveMin).keys()].map((i) => i + inclusiveMin);
 }
 
 export function randomPrice(min = 1, max = 100000): BigNumber {

--- a/packages/smart/test/crypto-factory-test.ts
+++ b/packages/smart/test/crypto-factory-test.ts
@@ -130,7 +130,6 @@ describe("CryptoFactory", function () {
       [0 as BigNumberish].concat(repeat(currentRound.id, PRICE_FEEDS.length)),
       nextResolutionTime
     );
-    console.log("MARINA", await tx.wait().then((r) => r.gasUsed));
   });
 
   it("CoinAdded logs are correct", async () => {


### PR DESCRIPTION
Some changes:
* Can add outcomes to a Futures market any time after it's created and before it begins resolving. Good for political markets since candidates enter the race late and still sometimes win.
* Resolution of a Futures market is now done in increments since otherwise it's possible to run out of gas when resolving.