### PR TITLE
order future outcomes and add marketId to outcomes

### DIFF
--- a/packages/comps/src/types.ts
+++ b/packages/comps/src/types.ts
@@ -250,7 +250,7 @@ export interface MarketInfo {
   initialOdds: string[];
   isPopular?: boolean;
   isFuture: boolean;
-  subMarkets?: { marketName: string; shareTokens: string[] }[];
+  subMarkets?: { marketName: string; shareTokens: string[]; marketType: number; factory: string; marketId: number }[];
   category?: string;
 }
 
@@ -267,6 +267,7 @@ export interface MarketOutcome {
   isInvalid?: boolean;
   isWinner?: boolean;
   subOutcomes?: SubOutcome[];
+  marketId?: string;
 }
 
 export interface AmmOutcome extends MarketOutcome {
@@ -275,6 +276,7 @@ export interface AmmOutcome extends MarketOutcome {
   ratio: string;
   balanceRaw: string;
   balance: string;
+  marketId?: string;
 }
 
 export interface Cash {

--- a/packages/comps/src/utils/constants.ts
+++ b/packages/comps/src/utils/constants.ts
@@ -33,6 +33,7 @@ export const OUTCOME_NO_NAME: string = "No";
 export const OUTCOME_INVALID_NAME: string = "Invalid";
 export const OUTCOME_NO_ID = 0;
 export const OUTCOME_YES_ID = 1;
+export const GROUP_INVALID_MARKET = 1;
 
 // Directions
 export const BUY: string = "buy";

--- a/packages/comps/src/utils/derived-futures-data.ts
+++ b/packages/comps/src/utils/derived-futures-data.ts
@@ -1,6 +1,13 @@
 import { BigNumber as BN } from "bignumber.js";
 import { MarketInfo } from "types";
-import { MMA_MARKET_TYPE, OUTCOME_YES_NAME, OUTCOME_NO_NAME, OUTCOME_NO_ID, OUTCOME_YES_ID } from "./constants";
+import {
+  MMA_MARKET_TYPE,
+  OUTCOME_YES_NAME,
+  OUTCOME_NO_NAME,
+  OUTCOME_NO_ID,
+  OUTCOME_YES_ID,
+  GROUP_INVALID_MARKET,
+} from "./constants";
 
 const FUTURE_CATEGORIES = {
   NFL: ["Sports", "Football", "NFL"],
@@ -12,6 +19,8 @@ export const deriveMarketInfo = (market: MarketInfo, marketData: any) => {
   const outcomes = market?.subMarkets.map((s, i) => ({
     id: i,
     name: s.marketName,
+    isInvalid: s.marketType === GROUP_INVALID_MARKET,
+    marketId: `${s.factory}-${String(s.marketId)}`.toLowerCase(),
     subOutcomes: [
       { id: OUTCOME_NO_ID, name: OUTCOME_NO_NAME, shareToken: s.shareTokens[OUTCOME_NO_ID] },
       { id: OUTCOME_YES_ID, name: OUTCOME_YES_NAME, shareToken: s.shareTokens[OUTCOME_YES_ID] },

--- a/packages/comps/src/utils/derived-market-data.ts
+++ b/packages/comps/src/utils/derived-market-data.ts
@@ -279,7 +279,11 @@ export const decodeFutureMarketDetailsFetcher = (marketData: any, factoryDetails
   marketInfo.amm = {
     ...pools[0],
     pools,
-    ammOutcomes: marketInfo.outcomes.map((o, i) => ({ ...o, price: pools[i].ammOutcomes[OUTCOME_YES_ID].price })),
+    ammOutcomes: marketInfo.outcomes.map((o, i) => ({
+      ...o,
+      price: pools[i].ammOutcomes[OUTCOME_YES_ID].price,
+      marketId: o.marketId,
+    })),
   };
 
   return marketInfo;


### PR DESCRIPTION
added isInvalid and ordered outcomes to be consistent with daily markets
added marketId to outcomes (market and amm) so sub market can be passed to contract-calls to add/remove liquidity or trade