### PR TITLE
Hosting Augur Turbo's simplified package on Crust network

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -45,6 +45,22 @@ jobs:
           yarn subgraph prepare:matic
           yarn subgraph codegen
           yarn subgraph deploy:matic --access-token ${{ secrets.GRAPH_TOKEN }}
+
+      - name: Pin to IPFS
+        id: upload
+        uses: crustio/ipfs-upload-action@v2.0.0
+        with:
+          path: './packages/simplified/build'
+          seeds: ${{ secrets.CRUST_SEEDS }}
+
+      - name: Pin to Crust
+        uses: crustio/ipfs-crust-action@v2.0.3
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          cid: ${{ steps.upload.outputs.hash }}
+          seeds: ${{ secrets.CRUST_SEEDS }}
+
       - name: Compress action step
         uses: master-atul/tar-action@v1.0.2
         id: compress

--- a/.github/workflows/test-crust.yml
+++ b/.github/workflows/test-crust.yml
@@ -1,0 +1,84 @@
+name: Test Crust
+
+on: # push
+  workflow_dispatch:
+
+jobs:
+  build:
+    # if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn
+      - run: VERSION=$(node -e "console.log(require('./lerna.json').version)") yarn build
+      - run: VERSION=$(node -e "console.log(require('./lerna.json').version)") NODE_OPTIONS="--max_old_space_size=6144" DEFAULT_NETWORK_ID="137" HIDE_FAUCET="true" yarn simp build
+      - run: yarn smart generate:environments
+      - name: Verify Changed files
+        uses: tj-actions/verify-changed-files@v6.2
+        id: verify-changed-files
+        with:
+         files: |
+          packages/smart/environments/matic.json
+          packages/smart/addresses.ts
+      # - name: Redeploy the subgraph when the environment changes
+      #   if: steps.verify-changed-files.outputs.files_changed == 'true'
+      #   run: |
+      #     yarn subgraph prepare:abis
+      #     yarn subgraph prepare:matic
+      #     yarn subgraph codegen
+      #     yarn subgraph deploy:matic --access-token ${{ secrets.GRAPH_TOKEN }}
+
+      - name: Pin to IPFS
+        id: upload
+        uses: crustio/ipfs-upload-action@v2.0.0
+        with:
+          path: './packages/simplified/build'
+          seeds: ${{ secrets.CRUST_SEEDS }}
+
+      - run: echo ${{ steps.upload.outputs.hash }}
+
+      - name: Pin to Crust
+        uses: crustio/ipfs-crust-action@v2.0.3
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          cid: ${{ steps.upload.outputs.hash }}
+          seeds: ${{ secrets.CRUST_SEEDS }}
+
+      # - name: Compress action step
+      #   uses: master-atul/tar-action@v1.0.2
+      #   id: compress
+      #   with:
+      #     command: c
+      #     cwd: ./packages/simplified/
+      #     files: |
+      #       ./build
+      #     outPath: release.tar.gz
+      # - name: Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     draft: true
+      #     files: |
+      #       LICENSE
+      #       release.tar.gz
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hey there!

These changes in the cd-release workflow enables pinning the simplified package build folder to IPFS and Crust network.
It adds 2 new steps to the build job: `Pin to IPFS` and `Pin to Crust`.

`Pin to IPFS` uploads the files in the build folder (`./packages/simplified/build`) to Crust's IPFS gateway and generates the corresponding CID as a variable named `hash`.
`Pin to Crust` takes that CID and places storage order on Crust network.

For this to work you need to set `CRUST_SEEDS` secret so please consider that before merging.

An alternative to using Crust's gateway for IPFS pinning is using the `aquiladev/ipfs-action@v0.1.6` github action which supports various IPFS pinning services like Pinata.

This submission is for [this](https://gitcoin.co/issue/crustio/crust/747/100026535) bounty on gitcoin.