### PR TITLE
cycle through the rpc endpoints to reduce load on any specific one

### DIFF
--- a/packages/comps/src/components/ConnectAccount/constants/index.tsx
+++ b/packages/comps/src/components/ConnectAccount/constants/index.tsx
@@ -11,7 +11,7 @@ export interface WalletInfo {
 
 export const MATIC_MUMBAI_RPCS = ['https://rpc-mumbai.maticvigil.com', 'https://matic-mumbai.chainstacklabs.com', 'https://matic-testnet-archive-rpc.bwarelabs.com'];
 export const MATIC_MUMBAI_BLOCK_EXPLORERS = ['https://explorer-mumbai.maticvigil.com', 'https://mumbai-explorer.matic.today', 'https://backup-mumbai-explorer.matic.today'];
-export const MATIC_RPCS = ['https://matic-mainnet-full-rpc.bwarelabs.com', 'https://rpc-mainnet.maticvigil.com', 'https://matic-mainnet.chainstacklabs.com','https://rpc-mainnet.matic.quiknode.pro', 'https://rpc-mainnet.matic.network','https://matic-mainnet-archive-rpc.bwarelabs.com'];
+export const MATIC_RPCS = ['https://polygon-rpc.com/', 'https://matic-mainnet-full-rpc.bwarelabs.com', 'https://rpc-mainnet.maticvigil.com', 'https://matic-mainnet.chainstacklabs.com','https://rpc-mainnet.matic.quiknode.pro', 'https://rpc-mainnet.matic.network','https://matic-mainnet-archive-rpc.bwarelabs.com'];
 export const MATIC_BLOCK_EXPLORERS = ['https://explorer-mainnet.maticvigil.com','https://explorer.matic.network','https://backup-explorer.matic.network'];
 
 export const MATIC_MUMBAI_RPC_DATA = {

--- a/packages/comps/src/components/ConnectAccount/utils/index.tsx
+++ b/packages/comps/src/components/ConnectAccount/utils/index.tsx
@@ -34,17 +34,20 @@ export const getRpcData = () => {
   return RPC_DATA;
 }
 
-let defaultProvider = null;
-const DEFAULT_RPC_INDEX = 1;
-export const getDefaultProvider = () => {
+let current_rpc_index = 0;
+export const getDefaultProvider = (): ethers.providers.StaticJsonRpcProvider => {
   const rpcData = getRpcData();
-  if (!defaultProvider){
-    defaultProvider = new ethers.providers.StaticJsonRpcProvider(
-      rpcData.rpcUrls[DEFAULT_RPC_INDEX],
-      Number(PARA_CONFIG.networkId)
-    );
-  }
-  return defaultProvider;
+  const data = getNextIndex(current_rpc_index, rpcData.rpcUrls);
+  current_rpc_index = data.index;
+  return new ethers.providers.StaticJsonRpcProvider(
+    data.value,
+    Number(PARA_CONFIG.networkId)
+  );
+}
+
+const getNextIndex = (currentIndex: number, collection) => {
+  if (currentIndex + 1 === collection.length) return { index: 0, value: collection[0] };
+  return { index: currentIndex + 1, value: collection[currentIndex + 1] };
 }
 
 export const isAddress = (value) => {

--- a/packages/comps/src/stores/data.tsx
+++ b/packages/comps/src/stores/data.tsx
@@ -50,7 +50,7 @@ export const DataProvider = ({ loadType = MARKET_LOAD_TYPE.SIMPLIFIED, children 
       const { account: userAccount, loginAccount } = UserStore.get();
       const { isRpcDown, isDegraded } = AppStatusStore.get();
       const { blocknumber: dblock, markets: dmarkets, ammExchanges: damm } = DataStore.get();
-      const provider = loginAccount?.library || defaultProvider?.current;
+      const provider = defaultProvider?.current || loginAccount?.library
       let infos = { markets: dmarkets, ammExchanges: damm, blocknumber: dblock };
       try {
         try {

--- a/packages/comps/src/stores/utils.ts
+++ b/packages/comps/src/stores/utils.ts
@@ -140,7 +140,7 @@ export function useUserBalances({ ammExchanges, blocknumber, cashes, markets, tr
         cashes,
         markets,
         transactions
-      ).then((userBalances) => updateUserBalances(userBalances));
+      ).then((userBalances) => updateUserBalances(userBalances)).catch(e => console.error('error fetching user balances, will try again'));
     }
   }, [loginAccount?.account, loginAccount?.library, blocknumber]);
 }

--- a/packages/comps/src/stores/utils.ts
+++ b/packages/comps/src/stores/utils.ts
@@ -133,14 +133,9 @@ export function useUserBalances({ ammExchanges, blocknumber, cashes, markets, tr
     };
 
     if (loginAccount?.library && loginAccount?.account) {
-      fetchUserBalances(
-        loginAccount.library,
-        loginAccount.account,
-        ammExchanges,
-        cashes,
-        markets,
-        transactions
-      ).then((userBalances) => updateUserBalances(userBalances)).catch(e => console.error('error fetching user balances, will try again'));
+      fetchUserBalances(loginAccount.library, loginAccount.account, ammExchanges, cashes, markets, transactions)
+        .then((userBalances) => updateUserBalances(userBalances))
+        .catch((e) => console.error("error fetching user balances, will try again"));
     }
   }, [loginAccount?.account, loginAccount?.library, blocknumber]);
 }

--- a/packages/comps/src/stores/utils.ts
+++ b/packages/comps/src/stores/utils.ts
@@ -6,6 +6,7 @@ import { ETH, TX_STATUS, ApprovalAction, ApprovalState, MARKET_STATUS } from "..
 import { useAppStatusStore } from "./app-status";
 import { useUserStore } from "./user";
 import { getUserBalances } from "../utils/contract-calls";
+import { getDefaultProvider } from "../components/ConnectAccount/utils";
 
 const isAsync = (obj) =>
   !!obj && (typeof obj === "object" || typeof obj === "function") && obj.constructor.name === "AsyncFunction";
@@ -126,8 +127,11 @@ export function useUserBalances({ ammExchanges, blocknumber, cashes, markets, tr
     actions: { updateUserBalances },
   } = useUserStore();
   useEffect(() => {
-    const fetchUserBalances = (library, account, ammExchanges, cashes, markets, transactions) =>
-      getUserBalances(library, account, ammExchanges, cashes, markets, transactions);
+    const fetchUserBalances = (library, account, ammExchanges, cashes, markets, transactions) => {
+      const provider = getDefaultProvider() || library;
+      return getUserBalances(provider, account, ammExchanges, cashes, markets, transactions);
+    };
+
     if (loginAccount?.library && loginAccount?.account) {
       fetchUserBalances(
         loginAccount.library,

--- a/packages/comps/src/utils/contract-calls.ts
+++ b/packages/comps/src/utils/contract-calls.ts
@@ -615,7 +615,7 @@ const chunkedMulticall = async (
   if (!contractCalls || contractCalls.length === 0) return results;
   if (contractCalls.length < chunkSize) {
     const res = await multicall.call(contractCalls).catch((e) => {
-      console.error("multicall", callingMethod, contractCalls, e);
+      console.error("multicall", callingMethod, contractCalls);
       throw e;
     });
     results = { results: res.results, blocknumber: res.blockNumber };
@@ -628,7 +628,7 @@ const chunkedMulticall = async (
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
       const call = await multicall.call(chunk).catch((e) => {
-        console.error(`multicall, ${callingMethod} chunking ${chunk.length} calls`, e);
+        console.error(`multicall, ${callingMethod} chunking ${chunk.length} calls`);
         throw e;
       });
       combined.blocknumber = call.blockNumber;

--- a/packages/comps/src/utils/contract-calls.ts
+++ b/packages/comps/src/utils/contract-calls.ts
@@ -2078,7 +2078,6 @@ const exchangesHaveLiquidity = async (exchanges: AmmExchanges, provider: Web3Pro
     const bpool = BPool__factory.connect(exchange.id, provider);
     const totalSupply = await bpool.totalSupply();
 
-    console.log("totalSupply", totalSupply);
     exchange.totalSupply = totalSupply ? totalSupply : "0";
     exchange.hasLiquidity = exchange.totalSupply !== "0";
   }

--- a/packages/smart/test/math.test.ts
+++ b/packages/smart/test/math.test.ts
@@ -27,7 +27,6 @@ describe("Math", () => {
   });
 });
 
-
 function calcSpreadWinner(homeScore: number, awayScore: number, spread: number): Winner {
   homeScore += spread;
 


### PR DESCRIPTION
each market data fetch loop through the rpc endpoints. removed the console log. screenshot used to demo
This will not use the user's MM for fetching market data from chain. If this strategy doesn't work or if we want to include MM we'll need to think through it. 

![Screen Shot 2021-09-13 at 4 02 51 PM](https://user-images.githubusercontent.com/3970376/133156305-b80c5ac7-7bfc-4a16-b697-840286f13c2f.png)
