### PR TITLE
use correct property for pool usdc in remove liquidity confirmation form

### DIFF
--- a/packages/comps/src/apollo/client.ts
+++ b/packages/comps/src/apollo/client.ts
@@ -224,10 +224,3 @@ const getClientConfig = (): { augurClient: string; blockClient: string; turboCli
   };
   return clientConfig[Number(networkId)];
 };
-
-const getCashesInfo = (): Cash[] => {
-  // this prob wont be used
-  // const { networkId } = PARA_CONFIG;
-
-  return [];
-};

--- a/packages/comps/src/utils/contract-calls.ts
+++ b/packages/comps/src/utils/contract-calls.ts
@@ -1676,7 +1676,10 @@ export const getMarketInfos = async (
 ): Promise<{ markets: MarketInfos; ammExchanges: AmmExchanges; blocknumber: number }> => {
   const factories = marketFactories(loadtype);
 
-  const allMarkets = await Promise.all(factories.map((config) => fetcherMarketsPerConfig(config, provider, account)));
+  // TODO: currently filtering out market factories that don't have rewards
+  const allMarkets = await Promise.all(
+    factories.filter((f) => f.hasRewards).map((config) => fetcherMarketsPerConfig(config, provider, account))
+  );
 
   // first market infos get all markets with liquidity
   const aMarkets = allMarkets.reduce((p, data) => ({ ...p, ...data.markets }), {});

--- a/packages/simplified/src/modules/liquidity/market-liquidity-view.tsx
+++ b/packages/simplified/src/modules/liquidity/market-liquidity-view.tsx
@@ -258,6 +258,8 @@ const LiquidityForm = ({ market, selectedAction, setSelectedAction, BackToLPPage
   const userTokenBalance = cash?.name ? balances[cash?.name]?.balance : "0";
   const shareBalance =
     balances && balances.lpTokens && balances.lpTokens[amm?.marketId] && balances.lpTokens[amm?.marketId].balance;
+  const liquidityUSD = 
+    balances && balances.lpTokens && balances.lpTokens[amm?.marketId] && balances.lpTokens[amm?.marketId].usdValue || "0";
   const userMaxAmount = isRemove ? shareBalance : userTokenBalance;
   const approvedToTransfer = ApprovalState.APPROVED;
   const isApprovedToTransfer = approvedToTransfer === ApprovalState.APPROVED;
@@ -481,7 +483,7 @@ const LiquidityForm = ({ market, selectedAction, setSelectedAction, BackToLPPage
                           infoNumbers: [
                             {
                               label: "Pooled USDC",
-                              value: `${formatCash(breakdown.amount, USDC).full}`,
+                              value: `${formatCash(liquidityUSD, USDC).full}`,
                               svg: USDCIcon,
                             },
                           ],

--- a/packages/simplified/src/modules/liquidity/market-liquidity-view.tsx
+++ b/packages/simplified/src/modules/liquidity/market-liquidity-view.tsx
@@ -209,11 +209,14 @@ const getCreateBreakdown = (breakdown, market, balances, isRemove = false) => {
       svg: isRemove ? USDCIcon : null,
     },
   ];
-  const pendingRewards = balances?.pendingRewards?.[market.marketId]?.balance || "0";
-  if (pendingRewards !== "0") {
+  const userRewards = balances?.pendingRewards?.[market.marketId];
+  const pendingRewards = userRewards ? userRewards.balance : "0";
+  const bonusRewards = userRewards && (new Date().getTime() / 1000) >= userRewards.endBonusTimestamp ? userRewards.pendingBonusRewards : "0";
+  const totalRewards = new BN(pendingRewards).plus(new BN(bonusRewards));
+  if (totalRewards.gt(ZERO)) {
     fullBreakdown.push({
       label: `LP Rewards`,
-      value: `${formatEther(pendingRewards).formatted}`,
+      value: `${formatEther(totalRewards).formatted}`,
       svg: MaticIcon,
     });
   }

--- a/packages/simplified/src/modules/modal/modal-add-liquidity.tsx
+++ b/packages/simplified/src/modules/modal/modal-add-liquidity.tsx
@@ -192,7 +192,7 @@ const ModalAddLiquidity = ({ market, liquidityModalType, currency }: ModalAddLiq
         totalPrice = totalPrice.plus(createBigNumber(price));
       }
     });
-    if (inputFormError === "" && !(new BN(totalPrice.toFixed(2))).eq(ONE) && !market.isFuture) {
+    if (inputFormError === "" && !(new BN(totalPrice.toFixed(2))).eq(ONE) && !market.isGrouped) {
       buttonError = INVALID_PRICE;
     }
   }
@@ -716,7 +716,7 @@ const ModalAddLiquidity = ({ market, liquidityModalType, currency }: ModalAddLiq
               dontFilterInvalid
               hasLiquidity={!mustSetPrices || hasInitialOdds}
               marketFactoryType={market?.marketFactoryType}
-              isFutures={market?.isFuture}
+              isGrouped={market?.isGrouped}
             />
           </section>
         )}


### PR DESCRIPTION
https://github.com/AugurProject/turbo/issues/1341
should use userBalances lptokens `usdValue`


![image](https://user-images.githubusercontent.com/3970376/135546568-f78d0b19-5fef-4dbc-9a93-048c6abe46fd.png)


Also add user's rewards and bonus (if bonus period is over)