### PR TITLE
Improvements to clear active bets on cashout from my bets

### DIFF
--- a/packages/sport/src/modules/betslip/betslip.tsx
+++ b/packages/sport/src/modules/betslip/betslip.tsx
@@ -525,26 +525,14 @@ const BetReciept = ({ tx_hash, bet }: { tx_hash: string; bet: ActiveBetType }) =
     isCashout,
     isWinningOutcome,
   });
-  if (status === TX_STATUS.PENDING) {
-    buttonName = `PENDING ${cashout.full}`;
+  if (!canCashOut) {
+    buttonName = CASHOUT_NOT_AVAILABLE;
     customClass = null;
-  } else if (isOpen) {
-    if (!canCashOut) {
-      buttonName = CASHOUT_NOT_AVAILABLE;
-    } else if (isApproved) {
-      buttonName = isPending ? `PENDING ${cashout.full}` : `CASHOUT ${cashout.full}`;
-    } else {
-      buttonName = `APPROVE CASHOUT ${cashout.full}`;
-    }
+  } else if (isApproved) {
+    buttonName = isPending ? `PENDING ${cashout.full}` : `CASHOUT ${cashout.full}`;
   } else {
-    // label won or lost
-    if (isCashout) {
-      subtext = `CASHOUT: ${cashout.full}`;
-    } else {
-      subtext = isWinningOutcome ? `WON: ${cashout.full}` : `LOSS: ${cashout.full}`;
-    }
+    buttonName = `APPROVE CASHOUT ${cashout.full}`;
   }
-
   return (
     <article className={classNames(Styles.BetReceipt, txStatus.class)}>
       <header>{heading}</header>

--- a/packages/sport/src/modules/stores/betslip.tsx
+++ b/packages/sport/src/modules/stores/betslip.tsx
@@ -130,6 +130,8 @@ const usePersistentActiveBets = ({ active, actions: { updateActive, addActive, r
   } = useUserStore();
   const { markets, transactions, blocknumber } = useDataStore();
 
+  const pendingTransactionCount = userTransactions.filter(transaction => transaction.status === TX_STATUS.PENDING);
+
   useEffect(async () => {
     if (!account) return null;
     const marketPositions = Object.keys(marketShares).reduce((p, marketId) => {
@@ -194,7 +196,7 @@ const usePersistentActiveBets = ({ active, actions: { updateActive, addActive, r
         active[bet.betId] ? updateActive(bet, true) : addActive(bet, true);
       });
     }
-  }, [account, blocknumber, Object.keys(marketShares).length]);
+  }, [account, blocknumber, Object.keys(marketShares).length, pendingTransactionCount.length]);
 };
 
 const useClearOnLogout = ({ actions: { clearBetslip } }) => {


### PR DESCRIPTION
updated my bets logic to remove active bets from the my bets page as they confirm instead of after the next block to prevent doubling up of information and confusion for the user