### PR TITLE
default to 0 for missing price

### DIFF
--- a/packages/sport/src/modules/common/tables.tsx
+++ b/packages/sport/src/modules/common/tables.tsx
@@ -169,7 +169,7 @@ const EventTableMain = ({ bets }: { [tx_hash: string]: ActiveBetType }) => {
               <span>{subHeading}</span>
             </li>
             <li>{wager === "0.00" ? "-" : formatCash(wager.replaceAll(',', ''), USDC).full}</li>
-            <li>{convertToOdds(convertToNormalizedPrice({ price }), oddsFormat).full}</li>
+            <li>{convertToOdds(convertToNormalizedPrice({ price: price || 0 }), oddsFormat).full}</li>
             <li>{toWin && toWin !== "0" ? formatCash(toWin.replaceAll(',', ''), USDC).full : "-"}</li>
             <li>{getMarketEndtimeFull(timestamp, timeFormat)}</li>
             <li>


### PR DESCRIPTION
default to 0 if we are missing price on a bet for any reason instead of blowing up the page