### PR TITLE
fix-add-remove-logs

### DIFF
--- a/packages/comps/src/stores/process-data.ts
+++ b/packages/comps/src/stores/process-data.ts
@@ -299,7 +299,7 @@ const prepareRemoveLiquidity = (transactions, market: MarketInfo, cash: Cash) =>
       bigUnitPostfix: false,
     }).full;
     const processed = sharedProcessed(remove, market, cash);
-    processed.tx_type = TransactionTypes.ADD_LIQUIDITY;
+    processed.tx_type = TransactionTypes.REMOVE_LIQUIDITY;
     processed.sender = remove.sender.id;
     processed.displayShares = lpTokens;
     processed.displayCollateral = formatCash(String(collateral.abs()), cash.name);


### PR DESCRIPTION
corrected a bad process removes function that was erroneously assigning `ADD_LIQUIDTY` as the type, instead of `REMOVE_LIQUIDITY`