### PR TITLE
fix-complete-sets-calc

### DIFF
--- a/packages/comps/src/utils/contract-calls.ts
+++ b/packages/comps/src/utils/contract-calls.ts
@@ -650,7 +650,7 @@ export const cashOutAllShares = (
 };
 
 export const getCompleteSetsAmount = (outcomeShares: string[], ammOutcomes): string => {
-  const shares = (ammOutcomes|| []).map((s, i) => new BN(outcomeShares[i] || "0"));
+  const shares = (ammOutcomes || []).map((s, i) => new BN(outcomeShares[i] || "0"));
   const amount = BigNumber.min(...shares);
   if (isNaN(Number(amount.toFixed()))) return "0";
   const isDust = amount.lte(DUST_POSITION_AMOUNT);
@@ -1029,8 +1029,8 @@ export const getUserBalances = async (
           userBalances[collection][marketId] = {
             ammExchange: exchange,
             positions: [],
-            outcomeSharesRaw: [],
-            outcomeShares: [],
+            outcomeSharesRaw: exchange.ammOutcomes.map((o) => null) || [],
+            outcomeShares: exchange.ammOutcomes.map((o) => null) || [],
           };
           // calc user position here **
           const position = getPositionUsdValues(

--- a/packages/comps/src/utils/contract-calls.ts
+++ b/packages/comps/src/utils/contract-calls.ts
@@ -649,8 +649,8 @@ export const cashOutAllShares = (
   );
 };
 
-export const getCompleteSetsAmount = (outcomeShares: string[]): string => {
-  const shares = (outcomeShares || []).map((s, i) => new BN(outcomeShares[i] || "0"));
+export const getCompleteSetsAmount = (outcomeShares: string[], ammOutcomes): string => {
+  const shares = (ammOutcomes|| []).map((s, i) => new BN(outcomeShares[i] || "0"));
   const amount = BigNumber.min(...shares);
   if (isNaN(Number(amount.toFixed()))) return "0";
   const isDust = amount.lte(DUST_POSITION_AMOUNT);

--- a/packages/simplified/src/modules/common/tables.tsx
+++ b/packages/simplified/src/modules/common/tables.tsx
@@ -266,10 +266,10 @@ export const PositionFooter = ({
         });
       });
   };
-  const hasCompleteSets = getCompleteSetsAmount(balances?.marketShares[marketId]?.outcomeShares) !== "0";
+  const hasCompleteSets = getCompleteSetsAmount(balances?.marketShares[marketId]?.outcomeShares, amm?.ammOutcomes) !== "0";
 
   if (!claimableWinnings && !showTradeButton && !hasCompleteSets) return null;
-
+  
   return (
     <div className={Styles.PositionFooter}>
       <span>

--- a/packages/simplified/src/modules/market/market-view.tsx
+++ b/packages/simplified/src/modules/market/market-view.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import Styles from "./market-view.styles.less";
-import ButtonStyles from '../common/buttons.styles.less';
+import ButtonStyles from "../common/buttons.styles.less";
 import classNames from "classnames";
 import SimpleChartSection from "../common/charts";
 import { PositionsLiquidityViewSwitcher, TransactionsTable } from "../common/tables";
@@ -142,9 +142,9 @@ const MarketView = ({ defaultMarket = null }) => {
   const { cashes, markets, ammExchanges, transactions } = useDataStore();
   useScrollToTopOnMount();
   const market: MarketInfo = !!defaultMarket ? defaultMarket : markets[marketId];
-
-  const selectedOutcome = market ? market.outcomes[1] : DefaultMarketOutcomes[1];
   const amm: AmmExchange = ammExchanges[marketId];
+  const hasInvalid = Boolean(amm?.ammOutcomes.find((o) => o.isInvalid));
+  const selectedOutcome = market ? (hasInvalid ? market.outcomes[1] : market.outcomes[0]) : DefaultMarketOutcomes[1];
 
   useEffect(() => {
     if (!market) {
@@ -163,7 +163,7 @@ const MarketView = ({ defaultMarket = null }) => {
   useEffect(() => {
     if (timeoutId && market) {
       clearTimeout(timeoutId);
-      timeoutId = null
+      timeoutId = null;
     }
   }, [market]);
 
@@ -240,7 +240,11 @@ const MarketView = ({ defaultMarket = null }) => {
           <span>Transactions</span>
           <TransactionsTable transactions={marketTransactions} />
         </div>
-        <SecondaryThemeButton text="Buy / Sell" action={() => setShowTradingForm(true)} customClass={ButtonStyles.BuySellButton} />
+        <SecondaryThemeButton
+          text="Buy / Sell"
+          action={() => setShowTradingForm(true)}
+          customClass={ButtonStyles.BuySellButton}
+        />
       </section>
       <section
         className={classNames({


### PR DESCRIPTION
make sure to check all outcomes for shares before deciding a complete set is available.

this fixes an issue where a user could see the cash out shares button but it would fail the transaction because they didn't actually have a complete set.