### PR TITLE
add estimation method and contract calling method with approval

### DIFF
--- a/packages/comps/src/stores/utils.ts
+++ b/packages/comps/src/stores/utils.ts
@@ -185,7 +185,7 @@ export function useScrollToTopOnMount(...optionsTriggers) {
   }, [...optionsTriggers]);
 }
 
-const { ADD_LIQUIDITY, REMOVE_LIQUIDITY, ENTER_POSITION, EXIT_POSITION, MINT_SETS } = ApprovalAction;
+const { ADD_LIQUIDITY, REMOVE_LIQUIDITY, ENTER_POSITION, EXIT_POSITION, MINT_SETS, RESET_PRICES } = ApprovalAction;
 export const { UNKNOWN, PENDING, APPROVED } = ApprovalState;
 export function useApprovalStatus({
   amm,
@@ -250,6 +250,13 @@ export function useApprovalStatus({
         case MINT_SETS: {
           address = amm?.cash?.address;
           spender = amm?.marketFactoryAddress;
+          checkApprovalFunction = checkAllowance;
+          break;
+        }
+        case RESET_PRICES: {
+          const { evenTheOdds } = PARA_CONFIG;
+          address = amm?.cash?.address;
+          spender = evenTheOdds;
           checkApprovalFunction = checkAllowance;
           break;
         }

--- a/packages/comps/src/types.ts
+++ b/packages/comps/src/types.ts
@@ -78,6 +78,7 @@ export interface ParaDeploys {
   balancerFactory: string;
   marketFactories: MarketFactory[];
   info: { uploadBlockNumber: number; graphName: string };
+  evenTheOdds: string;
 }
 export interface AmmTransaction {
   id: string;

--- a/packages/comps/src/utils/constants.ts
+++ b/packages/comps/src/utils/constants.ts
@@ -289,6 +289,7 @@ export enum ApprovalAction {
   ADD_LIQUIDITY,
   REMOVE_LIQUIDITY,
   MINT_SETS,
+  RESET_PRICES,
 }
 
 export const NULL_ADDRESS: string = "0x0000000000000000000000000000000000000000";
@@ -300,6 +301,7 @@ export const MODAL_CONNECT_TO_POLYGON: string = "MODAL_CONNECT_TO_POLYGON";
 
 export const CREATE: string = "create";
 export const MINT_SETS: string = "mintSets";
+export const RESET_PRICES: string = "resetPrices";
 
 export const DefaultMarketOutcomes = [
   {


### PR DESCRIPTION
To determine if market is out of whack:
      contract-calls `isMarketPoolWhacked `

get USDC value user will need to send: 
     contract-calls `maxWhackedCollateralAmount` collateralUsd property 

new constant for approval: ApprovalAction.RESET_PRICES

updated use approval, the user will only have to approve the helper contract once.

estimate resetting prices:
    contract-calls `estimateResetPrices` returns same structure as add liquidity
    
handling resetting prices submit tx is handled normally. It won't show up in user activities. 
